### PR TITLE
feat: 공통 응답 DTO 설정

### DIFF
--- a/apps/back/apps/application/auth/dto/request/login-with-email.dto.ts
+++ b/apps/back/apps/application/auth/dto/request/login-with-email.dto.ts
@@ -1,20 +1,19 @@
 import { IsEmail, IsString } from "class-validator";
+import { ApiProperty } from "@nestjs/swagger";
 
 export class LoginWithEmailDto {
-  /**
-   * 이메일
-   *
-   * @example user@gmail.com
-   */
+  @ApiProperty({
+    example: "user@gmail.com",
+    description: "이메일",
+  })
   @IsEmail()
   @IsString()
   email: string;
 
-  /**
-   * 비밀번호
-   *
-   * @example asdfasdf
-   */
+  @ApiProperty({
+    example: "asdfasdf",
+    description: "비밀번호",
+  })
   @IsString()
   password: string;
 }

--- a/apps/back/apps/application/auth/dto/response/login-result.dto.ts
+++ b/apps/back/apps/application/auth/dto/response/login-result.dto.ts
@@ -1,7 +1,11 @@
 import { Exclude, Expose } from "class-transformer";
+import { ApiProperty } from "@nestjs/swagger";
 
 @Exclude()
 export class LoginResultDto {
+  @ApiProperty({
+    example: "eyJhbGci",
+  })
   @Expose()
   token: string;
 }

--- a/apps/back/apps/application/auth/service/auth.service.ts
+++ b/apps/back/apps/application/auth/service/auth.service.ts
@@ -10,6 +10,10 @@ import { Repository } from "typeorm";
 import { LoginWithEmailDto } from "../dto/request/login-with-email.dto";
 import { LoginResultDto } from "../dto/response/login-result.dto";
 import { User } from "apps/domain/user/user.entity";
+import {
+  CustomResponse,
+  IResponse,
+} from "apps/application/common/response/response";
 
 @Injectable()
 export class AuthService {
@@ -20,12 +24,16 @@ export class AuthService {
   ) {}
 
   // 유저 이메일, 비밀번호로 인증 및 토큰발급
-  async loginUserWithEmail(dto: LoginWithEmailDto): Promise<LoginResultDto> {
+  async loginUserWithEmail(
+    dto: LoginWithEmailDto,
+  ): Promise<IResponse<LoginResultDto>> {
     const user = await this.authUserWithEmail(dto.email, dto.password);
 
-    return plainToInstance(LoginResultDto, {
+    const loginDto = plainToInstance(LoginResultDto, {
       token: await this.generateAccessToken(user.id),
     });
+
+    return new CustomResponse<LoginResultDto>(200, "A001", loginDto);
   }
 
   // 유저id 인증 및 토큰 발급

--- a/apps/back/apps/application/common/response/response.ts
+++ b/apps/back/apps/application/common/response/response.ts
@@ -1,0 +1,49 @@
+import { Type } from "@nestjs/common";
+import { ApiProperty } from "@nestjs/swagger";
+
+export interface IResponse<T> {
+  status: number;
+  code: string;
+  data: T;
+}
+
+export function ResponseDto<D>(
+  DtoClass: Type<D>,
+  resourceName: string,
+): Type<IResponse<D>> {
+  class ResponseHost<D> implements IResponse<D> {
+    @ApiProperty({ example: 200 })
+    status: number;
+
+    @ApiProperty({ example: "A001" })
+    code: string;
+
+    @ApiProperty({ type: () => DtoClass })
+    data: D;
+
+    constructor(status: number, code: string, data: D) {
+      this.status = status;
+      this.code = code;
+      this.data = data;
+    }
+  }
+
+  Object.defineProperty(ResponseHost, "name", {
+    writable: false,
+    value: `${resourceName}ResponseDto`,
+  });
+
+  return ResponseHost;
+}
+
+export class CustomResponse<E> implements IResponse<E> {
+  status: number;
+  code: string;
+  data: E;
+
+  constructor(status: number, code: string, data: E) {
+    this.status = status;
+    this.code = code;
+    this.data = data;
+  }
+}

--- a/apps/back/apps/front-api/src/auth/auth.controller.ts
+++ b/apps/back/apps/front-api/src/auth/auth.controller.ts
@@ -3,7 +3,11 @@ import { LoginWithEmailDto } from "apps/application/auth/dto/request/login-with-
 import { LoginResultDto } from "apps/application/auth/dto/response/login-result.dto";
 import { AuthService } from "apps/application/auth/service/auth.service";
 import { Public } from "apps/application/common/auth/public.decorator";
-import { ApiOperation } from "@nestjs/swagger";
+import { ApiOkResponse, ApiOperation } from "@nestjs/swagger";
+import {
+  IResponse,
+  ResponseDto,
+} from "apps/application/common/response/response";
 
 @Controller("auth")
 export class AuthController {
@@ -14,9 +18,14 @@ export class AuthController {
     operationId: "loginByEmail",
     tags: ["auth"],
   })
+  @ApiOkResponse({
+    type: ResponseDto(LoginResultDto, "LoginResult"),
+  })
   @Public()
   @Post("/login")
-  async loginByEmail(@Body() dto: LoginWithEmailDto): Promise<LoginResultDto> {
+  async loginByEmail(
+    @Body() dto: LoginWithEmailDto,
+  ): Promise<IResponse<LoginResultDto>> {
     return this.authService.loginUserWithEmail(dto);
   }
 }


### PR DESCRIPTION
## 📖 개요
- 공통 응답 DTO 추가
- 기존 auth api 예시의 응답 DTO에 수정사항 반영

## 💻 작업사항

- Response DTO를 통해 응답 형식 통일
![스크린샷 2024-07-30 오후 10 44 37](https://github.com/user-attachments/assets/4becb6ff-c407-45ad-9140-e1780d3a5255)


## 💡 작성한 이슈 외에 작업한 사항

- 모노레포에서 `@nestjs/swagger` 패키지가 자동으로 DTO 관련 타입을 간헐적으로 체크해주지 못하는 이슈가 있습니다.
- DTO마다 직접 하나하나 `@ApiProperty `달아주셔야할거 같습니다! 🥲

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
