### PR TITLE
feat: 회원가입 API 구현

### DIFF
--- a/apps/back/apps/admin-api/src/auth/auth.controller.ts
+++ b/apps/back/apps/admin-api/src/auth/auth.controller.ts
@@ -4,6 +4,7 @@ import { LoginResultDto } from "apps/application/auth/dto/response/login-result.
 import { AuthService } from "apps/application/auth/service/auth.service";
 import { Public } from "apps/application/common/auth/public.decorator";
 import { ApiOkResponse, ApiOperation } from "@nestjs/swagger";
+import { IResponse } from "apps/application/common/response/response";
 
 @Controller("auth")
 export class AuthController {
@@ -19,7 +20,9 @@ export class AuthController {
   })
   @Public()
   @Post("/login")
-  async loginByEmail(@Body() dto: LoginWithEmailDto): Promise<LoginResultDto> {
+  async loginByEmail(
+    @Body() dto: LoginWithEmailDto,
+  ): Promise<IResponse<LoginResultDto>> {
     return this.authService.loginUserWithEmail(dto);
   }
 }

--- a/apps/back/apps/application/auth/dto/request/sign-up.dto.ts
+++ b/apps/back/apps/application/auth/dto/request/sign-up.dto.ts
@@ -1,0 +1,68 @@
+import { IsBoolean, IsEmail, IsString, MaxLength } from "class-validator";
+import { ApiProperty } from "@nestjs/swagger";
+
+export class SignUpDto {
+  @ApiProperty({
+    example: "test",
+    description: "이름",
+  })
+  @IsString()
+  name: string;
+
+  @ApiProperty({
+    example: "user@gmail.com",
+    description: "이메일",
+  })
+  @IsEmail()
+  email: string;
+
+  @ApiProperty({
+    example: "asdfasdf",
+    description: "비밀번호",
+  })
+  @IsString()
+  password: string;
+
+  @ApiProperty({
+    example: "testNickname",
+    description: "닉네임",
+  })
+  @IsString()
+  nickname: string;
+
+  @ApiProperty({
+    example: "01011112222",
+    description: "전화번호",
+  })
+  @MaxLength(11)
+  @IsString()
+  phoneNumber: string;
+
+  @ApiProperty({
+    example: true,
+    description: "서비스 이용약관 동의 여부",
+  })
+  @IsBoolean()
+  isAgreed: boolean;
+
+  @ApiProperty({
+    example: true,
+    description: "개인정보 처리방침 동의 여부",
+  })
+  @IsBoolean()
+  isPrivacyAgreed: boolean;
+
+  @ApiProperty({
+    example: true,
+    description: "제3자 정보 제공 동의 여부",
+  })
+  @IsBoolean()
+  isThirdAgreed: boolean;
+
+  @ApiProperty({
+    example: true,
+    description: "마케팅 정보 수신 동의 여부(선택)",
+  })
+  @IsBoolean()
+  isMarketingAgreed: boolean;
+}

--- a/apps/back/apps/application/auth/service/auth.service.ts
+++ b/apps/back/apps/application/auth/service/auth.service.ts
@@ -2,8 +2,11 @@ import { Injectable } from "@nestjs/common";
 import { JwtService } from "@nestjs/jwt";
 import { InjectRepository } from "@nestjs/typeorm";
 import { UserRole } from "apps/domain/common/enum/role.enum";
-import { AuthFailedException } from "apps/infrastructure/error";
-import { compare } from "bcryptjs";
+import {
+  AuthFailedException,
+  RuntimeException,
+} from "apps/infrastructure/error";
+import { compare, hashSync } from "bcryptjs";
 import { plainToInstance } from "class-transformer";
 import { Repository } from "typeorm";
 
@@ -14,12 +17,23 @@ import {
   CustomResponse,
   IResponse,
 } from "apps/application/common/response/response";
+import { SignUpDto } from "apps/application/auth/dto/request/sign-up.dto";
+import { Transactional } from "typeorm-transactional";
+import { AgreementHistory } from "apps/domain/agreement/agreement-history/agreement-history.entity";
+import { AgreementVersion } from "apps/domain/agreement/agreement-version/agreement-version.entity";
+import { AgreementType } from "apps/domain/common/enum/agreement.enum";
+import { ErrorCode, ErrorMessage } from "apps/infrastructure/error/const";
 
 @Injectable()
 export class AuthService {
   constructor(
     @InjectRepository(User)
     private readonly userRepository: Repository<User>,
+    @InjectRepository(AgreementHistory)
+    private readonly agreementHistoryRepository: Repository<AgreementHistory>,
+    @InjectRepository(AgreementVersion)
+    private readonly agreementVersionRepository: Repository<AgreementVersion>,
+
     private readonly jwtService: JwtService,
   ) {}
 
@@ -81,9 +95,113 @@ export class AuthService {
     throw new AuthFailedException();
   }
 
+  // 회원가입
+  @Transactional()
+  async signUp(dto: SignUpDto): Promise<IResponse<LoginResultDto>> {
+    await this.validDuplicateEmail(dto.email);
+    await this.validDuplicateNickName(dto.nickname);
+
+    const user = new User();
+
+    user.name = dto.name;
+    user.email = dto.email;
+    user.password = hashSync(dto.password, 10);
+    user.nickname = dto.nickname;
+    user.phoneNumber = dto.phoneNumber;
+
+    user.isAgreed = dto.isAgreed;
+    user.isPrivacyAgreed = dto.isPrivacyAgreed;
+    user.isThirdAgreed = dto.isThirdAgreed;
+    user.isMarketingAgreed = dto.isMarketingAgreed;
+
+    const { id: userId } = await this.userRepository.save(user);
+
+    const serviceAgreementVersion =
+      await this.agreementVersionRepository.findOne({
+        where: { type: AgreementType.SERVICE, inUse: true },
+      });
+
+    const privacyAgreementVersion =
+      await this.agreementVersionRepository.findOne({
+        where: { type: AgreementType.PRIVACY, inUse: true },
+      });
+
+    const thirdAgreementVersion = await this.agreementVersionRepository.findOne(
+      {
+        where: { type: AgreementType.THIRD_PARTY, inUse: true },
+      },
+    );
+
+    const marketingAgreementVersion =
+      await this.agreementVersionRepository.findOne({
+        where: { type: AgreementType.MARKETING, inUse: true },
+      });
+
+    const agreementHistories = await Promise.all(
+      [
+        serviceAgreementVersion,
+        privacyAgreementVersion,
+        thirdAgreementVersion,
+        marketingAgreementVersion,
+      ].map((agreementVersion) => {
+        const agreementHistory = new AgreementHistory();
+
+        agreementHistory.userId = userId;
+        agreementHistory.agreementVersionId = agreementVersion.id;
+
+        switch (agreementVersion.type) {
+          case AgreementType.SERVICE:
+            agreementHistory.isAgreed = dto.isAgreed;
+            break;
+          case AgreementType.PRIVACY:
+            agreementHistory.isAgreed = dto.isPrivacyAgreed;
+            break;
+          case AgreementType.THIRD_PARTY:
+            agreementHistory.isAgreed = dto.isThirdAgreed;
+            break;
+          case AgreementType.MARKETING:
+            agreementHistory.isAgreed = dto.isMarketingAgreed;
+            break;
+        }
+
+        return agreementHistory;
+      }),
+    );
+
+    await this.agreementHistoryRepository.save(agreementHistories);
+
+    const loginResult = await this.loginUserWithId(userId);
+
+    return new CustomResponse<LoginResultDto>(200, "A001", loginResult);
+  }
+
   // JWT 액세스 토큰 생성
   async generateAccessToken(userId: number) {
     const payload = { sub: userId, role: UserRole.USER };
     return this.jwtService.sign(payload);
+  }
+
+  // 이메일 중복 체크
+  async validDuplicateEmail(email: string): Promise<void> {
+    const user = await this.userRepository.findOne({ where: { email } });
+
+    if (user) {
+      throw new RuntimeException(
+        ErrorMessage.DUPLICATE_EMAIL,
+        ErrorCode.DUPLICATE_EMAIL,
+      );
+    }
+  }
+
+  // 닉네임 중복 체크
+  async validDuplicateNickName(nickname: string): Promise<void> {
+    const user = await this.userRepository.findOne({ where: { nickname } });
+
+    if (user) {
+      throw new RuntimeException(
+        ErrorMessage.DUPLICATE_NICKNAME,
+        ErrorCode.DUPLICATE_NICKNAME,
+      );
+    }
   }
 }

--- a/apps/back/apps/domain/agreement/agreement-history/agreement-history.entity.ts
+++ b/apps/back/apps/domain/agreement/agreement-history/agreement-history.entity.ts
@@ -11,4 +11,7 @@ export class AgreementHistory extends DefaultEntity {
 
   @Column({ comment: "동의한 약관 버전 ID" })
   agreementVersionId: number;
+
+  @Column({ comment: "동의 여부" })
+  isAgreed: boolean;
 }

--- a/apps/back/apps/domain/user/user.entity.ts
+++ b/apps/back/apps/domain/user/user.entity.ts
@@ -22,6 +22,18 @@ export class User extends DefaultEntity {
   @Column()
   phoneNumber: string;
 
+  @Column()
+  isAgreed: boolean;
+
+  @Column()
+  isPrivacyAgreed: boolean;
+
+  @Column()
+  isThirdAgreed: boolean;
+
+  @Column()
+  isMarketingAgreed: boolean;
+
   @Column({ nullable: true, comment: "정산용 계좌 은행" })
   settlementBankName?: string;
 

--- a/apps/back/apps/front-api/src/auth/auth.controller.ts
+++ b/apps/back/apps/front-api/src/auth/auth.controller.ts
@@ -8,8 +8,9 @@ import {
   IResponse,
   ResponseDto,
 } from "apps/application/common/response/response";
+import { SignUpDto } from "apps/application/auth/dto/request/sign-up.dto";
 
-@Controller("auth")
+@Controller({ path: "auth", version: "1" })
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
@@ -27,5 +28,19 @@ export class AuthController {
     @Body() dto: LoginWithEmailDto,
   ): Promise<IResponse<LoginResultDto>> {
     return this.authService.loginUserWithEmail(dto);
+  }
+
+  @ApiOperation({
+    summary: "회원가입",
+    operationId: "signUp",
+    tags: ["auth"],
+  })
+  @ApiOkResponse({
+    type: ResponseDto(LoginResultDto, "LoginResult"),
+  })
+  @Public()
+  @Post("/signup")
+  async signUp(@Body() dto: SignUpDto): Promise<IResponse<LoginResultDto>> {
+    return this.authService.signUp(dto);
   }
 }

--- a/apps/back/apps/front-api/src/main.ts
+++ b/apps/back/apps/front-api/src/main.ts
@@ -8,12 +8,17 @@ import * as moment from "moment-timezone";
 import { Response } from "express";
 
 import { AppModule } from "./app.module";
+import { VersioningType } from "@nestjs/common";
 
 async function bootstrap() {
   moment.tz.setDefault("Asia/Seoul");
 
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
+
   app.enableCors();
+  app.enableVersioning({
+    type: VersioningType.URI,
+  });
   app.use(json({ limit: "100mb" }));
   app.use(urlencoded({ limit: "100mb", extended: true }));
   app.useLogger(new ApplicationLogger());

--- a/apps/back/apps/infrastructure/error/const.ts
+++ b/apps/back/apps/infrastructure/error/const.ts
@@ -1,0 +1,10 @@
+export const ErrorMessage = {
+  DUPLICATE_EMAIL: "이미 사용중인 이메일입니다.",
+  DUPLICATE_NICKNAME: "이미 사용중인 닉네임입니다.",
+};
+
+export const ErrorCode = {
+  // A: Auth - 인증 관련 에러 코드
+  DUPLICATE_EMAIL: "A002",
+  DUPLICATE_NICKNAME: "A003",
+};

--- a/apps/back/apps/infrastructure/error/index.ts
+++ b/apps/back/apps/infrastructure/error/index.ts
@@ -5,39 +5,40 @@ import {
   HttpStatus,
   NotFoundException,
   UnauthorizedException,
-} from '@nestjs/common';
+} from "@nestjs/common";
 
 /* 400 Bad Request */
 export class InvalidParameterException extends BadRequestException {
   constructor(message?: string, code?: string) {
-    super(message ?? '파라미터 에러', code ?? 'INVALID_PARAMETER');
+    super(message ?? "파라미터 에러", code ?? "INVALID_PARAMETER");
   }
 }
 
 /* 401 Unauthorized */
 export class AuthFailedException extends UnauthorizedException {
   constructor(message?: string, code?: string) {
-    super(message ?? '인증에 실패하였습니다.', code ?? 'AUTH_FAILED');
+    super(message ?? "인증에 실패하였습니다.", code ?? "AUTH_FAILED");
   }
 }
 
+/* 403 Forbidden */
 export class PermissionDeniedException extends UnauthorizedException {
   constructor(message?: string, code?: string) {
-    super(message ?? '권한이 없습니다.', code ?? 'PERMISSION_DENIED');
+    super(message ?? "권한이 없습니다.", code ?? "PERMISSION_DENIED");
   }
 }
 
 /* 404 Not Found */
 export class ResourceNotFoundException extends NotFoundException {
   constructor(message?: string, code?: string) {
-    super(message ?? '리소스를 찾지 못했습니다.', code ?? 'RESOURCE_NOT_FOUND');
+    super(message ?? "리소스를 찾지 못했습니다.", code ?? "RESOURCE_NOT_FOUND");
   }
 }
 
 /* 409 Conflict */
 export class RuntimeException extends ConflictException {
   constructor(message?: string, code?: string) {
-    super(message ?? '런타임 에러가 발생했습니다.', code ?? 'CONFLICT');
+    super(message ?? "런타임 에러가 발생했습니다.", code ?? "CONFLICT");
   }
 }
 
@@ -46,8 +47,8 @@ export class TooManyRequestsException extends HttpException {
   constructor(message?: string, code?: string) {
     super(
       HttpException.createBody(
-        message ?? '잠시 후 다시 요청해주세요.',
-        code ?? 'TOO_MANY_REQUESTS',
+        message ?? "잠시 후 다시 요청해주세요.",
+        code ?? "TOO_MANY_REQUESTS",
         HttpStatus.TOO_MANY_REQUESTS,
       ),
       HttpStatus.TOO_MANY_REQUESTS,

--- a/apps/back/apps/infrastructure/infrastructure.module.ts
+++ b/apps/back/apps/infrastructure/infrastructure.module.ts
@@ -36,6 +36,7 @@ import { EventHashtag } from "apps/domain/event/event-hashtag.entity";
 import { EventProduct } from "apps/domain/event/event-product.entity";
 import { Raffle } from "apps/domain/raffle/raffle.entity";
 import { RaffleHashtag } from "apps/domain/raffle/raffle-hashtag.entity";
+import { ConfigService } from "@nestjs/config";
 
 const entities = [
   AgreementHistory,
@@ -120,7 +121,7 @@ const clients = [NhnCloudService];
     }),
     TypeOrmModule.forFeature(entities),
   ],
-  providers: [...clients, ApplicationLogger],
+  providers: [...clients, ApplicationLogger, ConfigService],
   exports: [TypeOrmModule, ...clients, ApplicationLogger],
 })
 export class InfrastructureModule {

--- a/apps/back/db/seeds/agreement-version.seed.ts
+++ b/apps/back/db/seeds/agreement-version.seed.ts
@@ -1,0 +1,47 @@
+import { Injectable } from "@nestjs/common";
+import { Seeder } from "nestjs-seeder";
+import { InjectRepository } from "@nestjs/typeorm";
+import { AgreementVersion } from "apps/domain/agreement/agreement-version/agreement-version.entity";
+import { Repository } from "typeorm";
+import { AgreementType } from "apps/domain/common/enum/agreement.enum";
+
+@Injectable()
+export class AgreementVersionSeed implements Seeder {
+  constructor(
+    @InjectRepository(AgreementVersion)
+    private readonly agreementVersionRepository: Repository<AgreementVersion>,
+  ) {}
+
+  async seed(): Promise<void> {
+    const agreementVersions = [
+      {
+        type: AgreementType.SERVICE,
+        version: 1,
+        inUse: true,
+      },
+      {
+        type: AgreementType.PRIVACY,
+        version: 1,
+        inUse: true,
+      },
+      {
+        type: AgreementType.THIRD_PARTY,
+        version: 1,
+        inUse: true,
+      },
+      {
+        type: AgreementType.MARKETING,
+        version: 1,
+        inUse: true,
+      },
+    ];
+
+    await this.agreementVersionRepository.save(agreementVersions);
+  }
+
+  async drop(): Promise<any> {
+    return this.agreementVersionRepository.remove(
+      await this.agreementVersionRepository.find(),
+    );
+  }
+}

--- a/apps/back/db/seeds/seeder.ts
+++ b/apps/back/db/seeds/seeder.ts
@@ -1,0 +1,17 @@
+import { seeder } from "nestjs-seeder";
+import { AgreementVersionSeed } from "./agreement-version.seed";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { AgreementVersion } from "apps/domain/agreement/agreement-version/agreement-version.entity";
+import { InfrastructureModule } from "apps/infrastructure/infrastructure.module";
+import { ConfigModule } from "@nestjs/config";
+
+seeder({
+  imports: [
+    ConfigModule.forRoot({
+      envFilePath: ".env",
+      isGlobal: true,
+    }),
+    TypeOrmModule.forFeature([AgreementVersion]),
+    InfrastructureModule.forRoot(),
+  ],
+}).run([AgreementVersionSeed]);

--- a/apps/back/package.json
+++ b/apps/back/package.json
@@ -28,7 +28,9 @@
     "migration:run": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js migration:run",
     "migration:revert": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js migration:revert",
     "schema:drop": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js schema:drop",
-    "schema:sync": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js schema:sync"
+    "schema:sync": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js schema:sync",
+    "seed": "ts-node -r tsconfig-paths/register ./db/seeds/seeder.ts",
+    "seed:refresh": "ts-node -r tsconfig-paths/register ./db/seeds/seeder.ts --refresh"
   },
   "dependencies": {
     "@nestjs/common": "^10.3.10",
@@ -59,6 +61,7 @@
     "moment-timezone": "^0.5.35",
     "nanoid": "^5.0.7",
     "nest-winston": "^1.7.0",
+    "nestjs-seeder": "^0.3.2",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.0",
     "passport-local": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,9 @@ importers:
       nest-winston:
         specifier: ^1.7.0
         version: 1.9.7(@nestjs/common@10.3.10(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(winston@3.13.1)
+      nestjs-seeder:
+        specifier: ^0.3.2
+        version: 0.3.2(@faker-js/faker@8.4.1)
       passport:
         specifier: ^0.7.0
         version: 0.7.0
@@ -6743,6 +6746,11 @@ packages:
 
   nested-error-stacks@2.0.1:
     resolution: {integrity: sha512-SrQrok4CATudVzBS7coSz26QRSmlK9TzzoFbeKfcPBUFPjcQM9Rqvr/DlJkOrwI/0KcgvMub1n1g5Jt9EgRn4A==}
+
+  nestjs-seeder@0.3.2:
+    resolution: {integrity: sha512-dCuxmhWdjgAn1HT0K7ExuCmKQc7HCGihFgzYF4keVJkR94d+diVQQg9/K1aQFnBkH9XVuugUqi4OClfwt09XVQ==}
+    peerDependencies:
+      '@faker-js/faker': ^8.0.0
 
   next@14.2.5:
     resolution: {integrity: sha512-0f8aRfBVL+mpzfBjYfQuLWh2WyAwtJXCRfkPF4UJ5qd2YwrHczsrSzXU4tRMV0OAxR8ZJZWPFn6uhSC56UTsLA==}
@@ -18270,6 +18278,10 @@ snapshots:
       winston: 3.13.1
 
   nested-error-stacks@2.0.1: {}
+
+  nestjs-seeder@0.3.2(@faker-js/faker@8.4.1):
+    dependencies:
+      '@faker-js/faker': 8.4.1
 
   next@14.2.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:


### PR DESCRIPTION
## 📖 개요
- 회원가입 API 구현
## 💻 작업사항

- 유저 회원가입 API 구현
- 약관 동의 히스토리 및 버전 동의여부 칼럼 수정
- 약관 버전 시딩 추가

## 💡 작성한 이슈 외에 작업한 사항

- api 버저닝을 front-api 애플리케이션에 처리해두었습니다
- 에러코드/에러메세지 const로 추가해두었습니다

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
