### PR TITLE
feat: 이벤트 도메인 API 구현

### DIFF
--- a/apps/back/apps/application/application.module.ts
+++ b/apps/back/apps/application/application.module.ts
@@ -1,10 +1,11 @@
 import { Module } from "@nestjs/common";
 import { AuthModule } from "./auth/auth.module";
 import { CardModule } from "apps/application/card/card.module";
+import {EventModule} from "apps/application/event/event.module";
 
 @Module({
-  imports: [AuthModule, CardModule],
+  imports: [AuthModule, EventModule, CardModule],
   providers: [],
-  exports: [AuthModule, CardModule],
+  exports: [AuthModule, EventModule, CardModule],
 })
 export class ApplicationModule {}

--- a/apps/back/apps/application/event/dto/request/create-event.dto.ts
+++ b/apps/back/apps/application/event/dto/request/create-event.dto.ts
@@ -1,0 +1,101 @@
+import { ApiProperty } from "@nestjs/swagger";
+import {
+  IsArray,
+  IsDate,
+  IsInt,
+  IsString,
+  ValidateNested,
+} from "class-validator";
+import { Type } from "class-transformer";
+import { AddProductDto } from "apps/application/product/dto/request/add-product.dto";
+
+export class CreateEventDto {
+  @ApiProperty({
+    example: "이벤트 제목",
+    description: "이벤트 제목",
+  })
+  @IsString()
+  title: string;
+
+  @ApiProperty({
+    example: 10000,
+    description: "이벤트 가격",
+  })
+  @IsInt()
+  price: number;
+
+  @ApiProperty({
+    example: "2021-08-05T00:00:00.000Z",
+    description: "이벤트 시작일",
+  })
+  @IsDate()
+  @Type(() => Date)
+  startDate: Date;
+
+  @ApiProperty({
+    example: "2021-08-05T00:00:00.000Z",
+    description: "이벤트 종료일",
+  })
+  @IsDate()
+  @Type(() => Date)
+  endDate: Date;
+
+  @ApiProperty({
+    example: "2021-08-05T00:00:00.000Z",
+    description: "당첨 발표일",
+  })
+  @IsDate()
+  @Type(() => Date)
+  announceAt: Date;
+
+  @ApiProperty({
+    example: "이벤트 설명",
+    description: "이벤트 설명",
+  })
+  @IsString()
+  description: string;
+
+  @ApiProperty({
+    example: "기타",
+    description: "기타",
+  })
+  @IsString()
+  etc: string;
+
+  @ApiProperty({
+    example: 1,
+    description: "카테고리 ID",
+  })
+  @IsInt()
+  categoryId: number;
+
+  @ApiProperty({
+    example: [1, 2],
+    description: "태그 ID",
+  })
+  @IsInt({ each: true })
+  @IsArray()
+  tagIds: number[];
+
+  @ApiProperty({
+    example: ["이미지 URL"],
+    description: "이미지 URL",
+  })
+  @IsString({ each: true })
+  images: string[];
+
+  @ApiProperty({
+    example: [
+      {
+        title: "상품명",
+        imageUrl: "이미지 URL",
+        tagIds: [1, 2],
+      },
+    ],
+    description: "상품",
+  })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => AddProductDto)
+  products: AddProductDto[];
+}

--- a/apps/back/apps/application/event/dto/request/create-event.dto.ts
+++ b/apps/back/apps/application/event/dto/request/create-event.dto.ts
@@ -3,7 +3,7 @@ import {
   IsArray,
   IsDate,
   IsInt,
-  IsNotEmpty,
+  IsOptional,
   IsString,
   ValidateNested,
 } from "class-validator";
@@ -15,7 +15,6 @@ export class CreateEventDto {
     example: "이벤트 제목",
     description: "이벤트 제목",
   })
-  @IsNotEmpty()
   @IsString()
   title: string;
 
@@ -23,7 +22,6 @@ export class CreateEventDto {
     example: 10000,
     description: "이벤트 가격",
   })
-  @IsNotEmpty()
   @IsInt()
   price: number;
 
@@ -31,7 +29,6 @@ export class CreateEventDto {
     example: "2021-08-05T00:00:00.000Z",
     description: "이벤트 시작일",
   })
-  @IsNotEmpty()
   @IsDate()
   @Type(() => Date)
   startDate: Date;
@@ -40,7 +37,6 @@ export class CreateEventDto {
     example: "2021-08-05T00:00:00.000Z",
     description: "이벤트 종료일",
   })
-  @IsNotEmpty()
   @IsDate()
   @Type(() => Date)
   endDate: Date;
@@ -49,7 +45,6 @@ export class CreateEventDto {
     example: "2021-08-05T00:00:00.000Z",
     description: "당첨 발표일",
   })
-  @IsNotEmpty()
   @IsDate()
   @Type(() => Date)
   announceAt: Date;
@@ -58,7 +53,6 @@ export class CreateEventDto {
     example: "이벤트 설명",
     description: "이벤트 설명",
   })
-  @IsNotEmpty()
   @IsString()
   description: string;
 
@@ -66,7 +60,7 @@ export class CreateEventDto {
     example: "기타",
     description: "기타",
   })
-  @IsNotEmpty()
+  @IsOptional()
   @IsString()
   etc: string;
 
@@ -74,7 +68,6 @@ export class CreateEventDto {
     example: 1,
     description: "카테고리 ID",
   })
-  @IsNotEmpty()
   @IsInt()
   categoryId: number;
 
@@ -82,7 +75,6 @@ export class CreateEventDto {
     example: [1, 2],
     description: "태그 ID",
   })
-  @IsNotEmpty()
   @IsInt({ each: true })
   @IsArray()
   tagIds: number[];
@@ -91,7 +83,6 @@ export class CreateEventDto {
     example: ["이미지 URL"],
     description: "이미지 URL",
   })
-  @IsNotEmpty()
   @IsString({ each: true })
   images: string[];
 
@@ -105,7 +96,6 @@ export class CreateEventDto {
     ],
     description: "상품",
   })
-  @IsNotEmpty()
   @IsArray()
   @ValidateNested({ each: true })
   @Type(() => AddProductDto)

--- a/apps/back/apps/application/event/dto/request/create-event.dto.ts
+++ b/apps/back/apps/application/event/dto/request/create-event.dto.ts
@@ -3,6 +3,7 @@ import {
   IsArray,
   IsDate,
   IsInt,
+  IsNotEmpty,
   IsString,
   ValidateNested,
 } from "class-validator";
@@ -14,6 +15,7 @@ export class CreateEventDto {
     example: "이벤트 제목",
     description: "이벤트 제목",
   })
+  @IsNotEmpty()
   @IsString()
   title: string;
 
@@ -21,6 +23,7 @@ export class CreateEventDto {
     example: 10000,
     description: "이벤트 가격",
   })
+  @IsNotEmpty()
   @IsInt()
   price: number;
 
@@ -28,6 +31,7 @@ export class CreateEventDto {
     example: "2021-08-05T00:00:00.000Z",
     description: "이벤트 시작일",
   })
+  @IsNotEmpty()
   @IsDate()
   @Type(() => Date)
   startDate: Date;
@@ -36,6 +40,7 @@ export class CreateEventDto {
     example: "2021-08-05T00:00:00.000Z",
     description: "이벤트 종료일",
   })
+  @IsNotEmpty()
   @IsDate()
   @Type(() => Date)
   endDate: Date;
@@ -44,6 +49,7 @@ export class CreateEventDto {
     example: "2021-08-05T00:00:00.000Z",
     description: "당첨 발표일",
   })
+  @IsNotEmpty()
   @IsDate()
   @Type(() => Date)
   announceAt: Date;
@@ -52,6 +58,7 @@ export class CreateEventDto {
     example: "이벤트 설명",
     description: "이벤트 설명",
   })
+  @IsNotEmpty()
   @IsString()
   description: string;
 
@@ -59,6 +66,7 @@ export class CreateEventDto {
     example: "기타",
     description: "기타",
   })
+  @IsNotEmpty()
   @IsString()
   etc: string;
 
@@ -66,6 +74,7 @@ export class CreateEventDto {
     example: 1,
     description: "카테고리 ID",
   })
+  @IsNotEmpty()
   @IsInt()
   categoryId: number;
 
@@ -73,6 +82,7 @@ export class CreateEventDto {
     example: [1, 2],
     description: "태그 ID",
   })
+  @IsNotEmpty()
   @IsInt({ each: true })
   @IsArray()
   tagIds: number[];
@@ -81,6 +91,7 @@ export class CreateEventDto {
     example: ["이미지 URL"],
     description: "이미지 URL",
   })
+  @IsNotEmpty()
   @IsString({ each: true })
   images: string[];
 
@@ -94,6 +105,7 @@ export class CreateEventDto {
     ],
     description: "상품",
   })
+  @IsNotEmpty()
   @IsArray()
   @ValidateNested({ each: true })
   @Type(() => AddProductDto)

--- a/apps/back/apps/application/event/dto/request/modify-event.dto.ts
+++ b/apps/back/apps/application/event/dto/request/modify-event.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsArray, IsDate, IsInt, IsNotEmpty, IsString } from "class-validator";
+import { IsArray, IsDate, IsInt, IsOptional, IsString } from "class-validator";
 import { Type } from "class-transformer";
 
 export class ModifyEventDto {
@@ -7,7 +7,6 @@ export class ModifyEventDto {
     example: "이벤트 제목",
     description: "이벤트 제목",
   })
-  @IsNotEmpty()
   @IsString()
   title: string;
 
@@ -15,7 +14,6 @@ export class ModifyEventDto {
     example: 10000,
     description: "이벤트 가격",
   })
-  @IsNotEmpty()
   @IsInt()
   price: number;
 
@@ -23,7 +21,6 @@ export class ModifyEventDto {
     example: "2021-08-05T00:00:00.000Z",
     description: "이벤트 시작일",
   })
-  @IsNotEmpty()
   @IsDate()
   @Type(() => Date)
   startDate: Date;
@@ -32,7 +29,6 @@ export class ModifyEventDto {
     example: "2021-08-05T00:00:00.000Z",
     description: "이벤트 종료일",
   })
-  @IsNotEmpty()
   @IsDate()
   @Type(() => Date)
   endDate: Date;
@@ -41,7 +37,6 @@ export class ModifyEventDto {
     example: "2021-08-05T00:00:00.000Z",
     description: "당첨 발표일",
   })
-  @IsNotEmpty()
   @IsDate()
   @Type(() => Date)
   announceAt: Date;
@@ -50,7 +45,6 @@ export class ModifyEventDto {
     example: "이벤트 설명",
     description: "이벤트 설명",
   })
-  @IsNotEmpty()
   @IsString()
   description: string;
 
@@ -58,7 +52,7 @@ export class ModifyEventDto {
     example: "기타",
     description: "기타",
   })
-  @IsNotEmpty()
+  @IsOptional()
   @IsString()
   etc: string;
 
@@ -66,7 +60,6 @@ export class ModifyEventDto {
     example: 1,
     description: "카테고리 ID",
   })
-  @IsNotEmpty()
   @IsInt()
   categoryId: number;
 
@@ -74,7 +67,6 @@ export class ModifyEventDto {
     example: [1, 2],
     description: "태그 ID",
   })
-  @IsNotEmpty()
   @IsInt({ each: true })
   @IsArray()
   tagIds: number[];
@@ -83,7 +75,6 @@ export class ModifyEventDto {
     example: ["이미지 URL"],
     description: "이미지 URL",
   })
-  @IsNotEmpty()
   @IsString({ each: true })
   images: string[];
 }

--- a/apps/back/apps/application/event/dto/request/modify-event.dto.ts
+++ b/apps/back/apps/application/event/dto/request/modify-event.dto.ts
@@ -1,0 +1,89 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsArray, IsDate, IsInt, IsNotEmpty, IsString } from "class-validator";
+import { Type } from "class-transformer";
+
+export class ModifyEventDto {
+  @ApiProperty({
+    example: "이벤트 제목",
+    description: "이벤트 제목",
+  })
+  @IsNotEmpty()
+  @IsString()
+  title: string;
+
+  @ApiProperty({
+    example: 10000,
+    description: "이벤트 가격",
+  })
+  @IsNotEmpty()
+  @IsInt()
+  price: number;
+
+  @ApiProperty({
+    example: "2021-08-05T00:00:00.000Z",
+    description: "이벤트 시작일",
+  })
+  @IsNotEmpty()
+  @IsDate()
+  @Type(() => Date)
+  startDate: Date;
+
+  @ApiProperty({
+    example: "2021-08-05T00:00:00.000Z",
+    description: "이벤트 종료일",
+  })
+  @IsNotEmpty()
+  @IsDate()
+  @Type(() => Date)
+  endDate: Date;
+
+  @ApiProperty({
+    example: "2021-08-05T00:00:00.000Z",
+    description: "당첨 발표일",
+  })
+  @IsNotEmpty()
+  @IsDate()
+  @Type(() => Date)
+  announceAt: Date;
+
+  @ApiProperty({
+    example: "이벤트 설명",
+    description: "이벤트 설명",
+  })
+  @IsNotEmpty()
+  @IsString()
+  description: string;
+
+  @ApiProperty({
+    example: "기타",
+    description: "기타",
+  })
+  @IsNotEmpty()
+  @IsString()
+  etc: string;
+
+  @ApiProperty({
+    example: 1,
+    description: "카테고리 ID",
+  })
+  @IsNotEmpty()
+  @IsInt()
+  categoryId: number;
+
+  @ApiProperty({
+    example: [1, 2],
+    description: "태그 ID",
+  })
+  @IsNotEmpty()
+  @IsInt({ each: true })
+  @IsArray()
+  tagIds: number[];
+
+  @ApiProperty({
+    example: ["이미지 URL"],
+    description: "이미지 URL",
+  })
+  @IsNotEmpty()
+  @IsString({ each: true })
+  images: string[];
+}

--- a/apps/back/apps/application/event/dto/response/create-event-result.dto.ts
+++ b/apps/back/apps/application/event/dto/response/create-event-result.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class CreateEventResultDto {
+  @ApiProperty({
+    example: 1,
+    description: "이벤트 ID",
+  })
+  id: number;
+
+  @ApiProperty({
+    example: "이벤트 썸네일 URL",
+    description: "이벤트 썸네일",
+  })
+  thumbnail: string;
+}

--- a/apps/back/apps/application/event/dto/response/get-event.dto.ts
+++ b/apps/back/apps/application/event/dto/response/get-event.dto.ts
@@ -1,5 +1,4 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsInt, IsString } from "class-validator";
 import { GetProductDto } from "apps/application/product/dto/request/get-product.dto";
 import { Exclude } from "class-transformer";
 import { EventHashtag } from "apps/domain/event/event-hashtag.entity";
@@ -10,14 +9,12 @@ export class GetEventDto {
     example: 1,
     description: "이벤트 ID",
   })
-  @IsInt()
   id: number;
 
   @ApiProperty({
     example: "EVENT",
     description: "타입",
   })
-  @IsString()
   type: string;
 
   @ApiProperty({

--- a/apps/back/apps/application/event/dto/response/get-event.dto.ts
+++ b/apps/back/apps/application/event/dto/response/get-event.dto.ts
@@ -78,10 +78,10 @@ export class GetEventDto {
   createUserId: number;
 
   @ApiProperty({
-    example: "[1, 2, 3]",
-    description: "태그 ID 리스트",
+    example: "[ '태그1', '태그2' ]",
+    description: "태그 리스트",
   })
-  tagIds: number[];
+  tags: string[];
 
   @ApiProperty({
     example: "[ '이미지 URL1', '이미지 URL2' ]",

--- a/apps/back/apps/application/event/dto/response/get-event.dto.ts
+++ b/apps/back/apps/application/event/dto/response/get-event.dto.ts
@@ -1,5 +1,9 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsInt } from "class-validator";
+import { IsInt, IsString } from "class-validator";
+import { GetProductDto } from "apps/application/product/dto/request/get-product.dto";
+import { Exclude } from "class-transformer";
+import { EventHashtag } from "apps/domain/event/event-hashtag.entity";
+import { EventProduct } from "apps/domain/event/event-product.entity";
 
 export class GetEventDto {
   @ApiProperty({
@@ -8,6 +12,13 @@ export class GetEventDto {
   })
   @IsInt()
   id: number;
+
+  @ApiProperty({
+    example: "EVENT",
+    description: "타입",
+  })
+  @IsString()
+  type: string;
 
   @ApiProperty({
     example: "이벤트 제목",
@@ -58,6 +69,12 @@ export class GetEventDto {
   applyCount: number;
 
   @ApiProperty({
+    example: "waiting",
+    description: "이벤트 상태",
+  })
+  status: string;
+
+  @ApiProperty({
     example: "1",
     description: "이벤트 주최자 ID",
   })
@@ -74,4 +91,24 @@ export class GetEventDto {
     description: "이미지 URL 리스트",
   })
   images: string[];
+
+  @ApiProperty({
+    example: [
+      {
+        id: 1,
+        name: "상품 이름",
+        price: 10000,
+        imageUrl: "상품 이미지 URL",
+        tagIds: [1, 2, 3],
+      },
+    ],
+    description: "상품 리스트",
+  })
+  products: GetProductDto[];
+
+  @Exclude()
+  eventHashtags: EventHashtag[];
+
+  @Exclude()
+  eventProducts: EventProduct[];
 }

--- a/apps/back/apps/application/event/dto/response/get-event.dto.ts
+++ b/apps/back/apps/application/event/dto/response/get-event.dto.ts
@@ -1,0 +1,77 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsInt } from "class-validator";
+
+export class GetEventDto {
+  @ApiProperty({
+    example: 1,
+    description: "이벤트 ID",
+  })
+  @IsInt()
+  id: number;
+
+  @ApiProperty({
+    example: "이벤트 제목",
+    description: "이벤트 제목",
+  })
+  title: string;
+
+  @ApiProperty({
+    example: 10000,
+    description: "이벤트 가격",
+  })
+  price: number;
+
+  @ApiProperty({
+    example: "2021-08-05T00:00:00.000Z",
+    description: "이벤트 시작일",
+  })
+  startDate: Date;
+
+  @ApiProperty({
+    example: "2021-08-05T00:00:00.000Z",
+    description: "이벤트 종료일",
+  })
+  endDate: Date;
+
+  @ApiProperty({
+    example: "2021-08-05T00:00:00.000Z",
+    description: "당첨 발표일",
+  })
+  announceAt: Date;
+
+  @ApiProperty({
+    example: "이벤트 유의사항",
+    description: "이벤트 유의사항",
+  })
+  etc: string;
+
+  @ApiProperty({
+    example: "10",
+    description: "스크랩 수",
+  })
+  clipCount: number;
+
+  @ApiProperty({
+    example: "10",
+    description: "이벤트 응모자 수",
+  })
+  applyCount: number;
+
+  @ApiProperty({
+    example: "1",
+    description: "이벤트 주최자 ID",
+  })
+  createUserId: number;
+
+  @ApiProperty({
+    example: "[1, 2, 3]",
+    description: "태그 ID 리스트",
+  })
+  tagIds: number[];
+
+  @ApiProperty({
+    example: "[ '이미지 URL1', '이미지 URL2' ]",
+    description: "이미지 URL 리스트",
+  })
+  images: string[];
+}

--- a/apps/back/apps/application/event/event.module.ts
+++ b/apps/back/apps/application/event/event.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import {TypeOrmModule} from "@nestjs/typeorm";
+import {EventService} from "apps/application/event/service/event.service";
+
+@Module({
+    imports: [TypeOrmModule.forFeature([Event])],
+    providers: [EventService],
+    exports: [EventService],
+})
+export class EventModule {}

--- a/apps/back/apps/application/event/event.module.ts
+++ b/apps/back/apps/application/event/event.module.ts
@@ -1,10 +1,8 @@
 import { Module } from "@nestjs/common";
 import { EventService } from "apps/application/event/service/event.service";
-import { EventController } from "apps/front-api/src/event/event.controller";
 
 @Module({
   providers: [EventService],
   exports: [EventService],
-  controllers: [EventController],
 })
 export class EventModule {}

--- a/apps/back/apps/application/event/event.module.ts
+++ b/apps/back/apps/application/event/event.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import {TypeOrmModule} from "@nestjs/typeorm";
 import {EventService} from "apps/application/event/service/event.service";
+import {Event} from "apps/domain/event/event.entity";
 
 @Module({
     imports: [TypeOrmModule.forFeature([Event])],

--- a/apps/back/apps/application/event/event.module.ts
+++ b/apps/back/apps/application/event/event.module.ts
@@ -1,8 +1,10 @@
 import { Module } from "@nestjs/common";
 import { EventService } from "apps/application/event/service/event.service";
+import { EventController } from "apps/front-api/src/event/event.controller";
 
 @Module({
   providers: [EventService],
   exports: [EventService],
+  controllers: [EventController],
 })
 export class EventModule {}

--- a/apps/back/apps/application/event/event.module.ts
+++ b/apps/back/apps/application/event/event.module.ts
@@ -1,11 +1,8 @@
-import { Module } from '@nestjs/common';
-import {TypeOrmModule} from "@nestjs/typeorm";
-import {EventService} from "apps/application/event/service/event.service";
-import {Event} from "apps/domain/event/event.entity";
+import { Module } from "@nestjs/common";
+import { EventService } from "apps/application/event/service/event.service";
 
 @Module({
-    imports: [TypeOrmModule.forFeature([Event])],
-    providers: [EventService],
-    exports: [EventService],
+  providers: [EventService],
+  exports: [EventService],
 })
 export class EventModule {}

--- a/apps/back/apps/application/event/interceptor/event-view-count.interceptor.ts
+++ b/apps/back/apps/application/event/interceptor/event-view-count.interceptor.ts
@@ -1,0 +1,26 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from "@nestjs/common";
+import { EventService } from "apps/application/event/service/event.service";
+import { Observable, tap } from "rxjs";
+
+@Injectable()
+export class EventViewCountInterceptor implements NestInterceptor {
+  constructor(private readonly eventService: EventService) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const request = context.switchToHttp().getRequest();
+    const eventId = request.params.id;
+
+    return next.handle().pipe(
+      tap(async () => {
+        if (eventId) {
+          await this.eventService.increaseViewCount(eventId);
+        }
+      }),
+    );
+  }
+}

--- a/apps/back/apps/application/event/interceptor/event-view-count.interceptor.ts
+++ b/apps/back/apps/application/event/interceptor/event-view-count.interceptor.ts
@@ -11,6 +11,7 @@ import { Observable, tap } from "rxjs";
 export class EventViewCountInterceptor implements NestInterceptor {
   constructor(private readonly eventService: EventService) {}
 
+  // TODO: 추후 Redis에 키로 저장하여 스케쥴러로 한 번에 업데이트 하도록 구현
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
     const request = context.switchToHttp().getRequest();
     const eventId = request.params.id;

--- a/apps/back/apps/application/event/service/event.service.ts
+++ b/apps/back/apps/application/event/service/event.service.ts
@@ -17,6 +17,7 @@ import { Transactional } from "typeorm-transactional";
 import { Images } from "apps/domain/image/image.entity";
 import { RaffleType } from "apps/domain/common/enum/raffle.enum";
 import { ProductHashtag } from "apps/domain/product/product-hashtag.entity";
+import { GetEventDto } from "apps/application/event/dto/response/get-event.dto";
 
 @Injectable()
 export class EventService {
@@ -106,8 +107,22 @@ export class EventService {
 
     return new CustomResponse<CreateEventResultDto>(
       200,
-      "A001",
+      "E001",
       createEventResultDto,
     );
+  }
+
+  async getEventById(id: number): Promise<IResponse<GetEventDto>> {
+    const event = await this.eventRepository.findOne({
+      where: {
+        id: id,
+      },
+    });
+
+    const getEventDto = plainToInstance(GetEventDto, event);
+
+    const eventDto = plainToInstance(GetEventDto, event);
+
+    return new CustomResponse<GetEventDto>(200, "E002", eventDto);
   }
 }

--- a/apps/back/apps/application/event/service/event.service.ts
+++ b/apps/back/apps/application/event/service/event.service.ts
@@ -1,0 +1,11 @@
+import {Injectable} from "@nestjs/common";
+import {InjectRepository} from "@nestjs/typeorm";
+import {Repository} from "typeorm";
+
+@Injectable()
+export class EventService {
+    constructor(
+        @InjectRepository(Event)
+        private readonly eventRepository: Repository<Event>,
+    ) {}
+}

--- a/apps/back/apps/application/event/service/event.service.ts
+++ b/apps/back/apps/application/event/service/event.service.ts
@@ -1,11 +1,113 @@
-import {Injectable} from "@nestjs/common";
-import {InjectRepository} from "@nestjs/typeorm";
-import {Repository} from "typeorm";
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import { Event } from "apps/domain/event/event.entity";
+import { CreateEventDto } from "apps/application/event/dto/request/create-event.dto";
+import {
+  CustomResponse,
+  IResponse,
+} from "apps/application/common/response/response";
+import { CreateEventResultDto } from "apps/application/event/dto/response/create-event-result.dto";
+import { plainToInstance } from "class-transformer";
+import { Product } from "apps/domain/product/product.entity";
+import { EventProduct } from "apps/domain/event/event-product.entity";
+import { EventHashtag } from "apps/domain/event/event-hashtag.entity";
+import { Hashtag } from "apps/domain/hashtag/hashtag.entity";
+import { Transactional } from "typeorm-transactional";
+import { Images } from "apps/domain/image/image.entity";
+import { RaffleType } from "apps/domain/common/enum/raffle.enum";
+import { ProductHashtag } from "apps/domain/product/product-hashtag.entity";
 
 @Injectable()
 export class EventService {
-    constructor(
-        @InjectRepository(Event)
-        private readonly eventRepository: Repository<Event>,
-    ) {}
+  constructor(
+    @InjectRepository(Event)
+    private readonly eventRepository: Repository<Event>,
+    @InjectRepository(Product)
+    private readonly productRepository: Repository<Product>,
+    @InjectRepository(Images)
+    private readonly imagesRepository: Repository<Images>,
+    @InjectRepository(ProductHashtag)
+    private readonly productHashtagRepository: Repository<ProductHashtag>,
+    @InjectRepository(EventProduct)
+    private readonly eventProductRepository: Repository<EventProduct>,
+    @InjectRepository(EventHashtag)
+    private readonly eventHashtagRepository: Repository<EventHashtag>,
+  ) {}
+
+  @Transactional()
+  async createEvent(
+    dto: CreateEventDto,
+  ): Promise<IResponse<CreateEventResultDto>> {
+    // 이벤트 생성
+    // TODO: SignUp API 추가 되면 테스트 후 @CurrentUser()로 사용자 정보 가져와서 createUserId에 넣어주기
+    const event = this.eventRepository.create({
+      ...dto,
+      thumbnail: dto.images[0],
+      createUserId: 2,
+    });
+
+    await this.eventRepository.save(event);
+
+    // 이벤트 상품 생성 및 매핑
+    const products = await this.productRepository.save(
+      dto.products.map((product) => this.productRepository.create(product)),
+    );
+
+    // 상품 및 이벤트 이미지 매핑
+    const images = [
+      // 상품 이미지 매핑
+      ...products.map((product) => ({
+        url: product.imageUrl,
+        type: RaffleType.PRODUCT,
+        targetId: product.id,
+      })),
+      // 이벤트 이미지 매핑
+      ...dto.images.map((image) => ({
+        url: image,
+        type: RaffleType.EVENT,
+        targetId: event.id,
+      })),
+    ];
+    await this.imagesRepository.save(images);
+
+    // 상품-해시태그 테이블에 매핑
+    const productHashtags = dto.products.map((product, index) => ({
+      productId: products[index].id,
+      hashtagId: product.tagIds[index],
+      product: products[index],
+      hashtag: { id: product.tagIds[index] } as Hashtag,
+    }));
+    await this.productHashtagRepository.save(productHashtags);
+
+    // 이벤트-상품 테이블에 매핑
+    const eventProducts = products.map((product) => ({
+      eventId: event.id,
+      productId: product.id,
+      event,
+      product,
+    }));
+    await this.eventProductRepository.save(eventProducts);
+
+    // 이벤트-해시태그 테이블에 매핑
+    const eventHashtags = dto.tagIds.map((tagId) => ({
+      eventId: event.id,
+      hashtagId: tagId,
+      event,
+      hashtag: { id: tagId } as Hashtag,
+    }));
+    await this.eventHashtagRepository.save(eventHashtags);
+
+    // 이벤트 생성 결과 DTO 생성
+    const createEventResultDto = plainToInstance(CreateEventResultDto, {
+      id: event.id,
+      thumbnail: event.thumbnail,
+    });
+
+    return new CustomResponse<CreateEventResultDto>(
+      200,
+      "A001",
+      createEventResultDto,
+    );
+  }
 }

--- a/apps/back/apps/application/event/service/event.service.ts
+++ b/apps/back/apps/application/event/service/event.service.ts
@@ -238,7 +238,7 @@ export class EventService {
 
   async increaseViewCount(id: number): Promise<void> {
     const event = await this.eventRepository.findOne({ where: { id } });
-    if (event.isDeleted) {
+    if (!event || event.isDeleted) {
       return;
     }
     await this.eventRepository.increment({ id }, "viewCount", 1);

--- a/apps/back/apps/application/event/service/event.service.ts
+++ b/apps/back/apps/application/event/service/event.service.ts
@@ -20,7 +20,6 @@ import { ProductHashtag } from "apps/domain/product/product-hashtag.entity";
 import { GetEventDto } from "apps/application/event/dto/response/get-event.dto";
 import { ModifyEventDto } from "apps/application/event/dto/request/modify-event.dto";
 
-// TODO: Error 처리는 추후에 통일
 @Injectable()
 export class EventService {
   constructor(
@@ -38,6 +37,7 @@ export class EventService {
     private readonly eventHashtagRepository: Repository<EventHashtag>,
   ) {}
 
+  // TODO: Error 처리는 추후에 통일
   // TODO: SignUp API 추가 되면 테스트 후 @CurrentUser()로 사용자 정보 가져와서 createUserId에 넣어주기
   @Transactional()
   async createEvent(

--- a/apps/back/apps/application/event/service/event.service.ts
+++ b/apps/back/apps/application/event/service/event.service.ts
@@ -120,13 +120,47 @@ export class EventService {
         id: id,
         isDeleted: false,
       },
+      select: [
+        "id",
+        "title",
+        "price",
+        "startDate",
+        "endDate",
+        "announceAt",
+        "description",
+        "etc",
+        "status",
+        "clipCount",
+        "applyCount",
+        "createUserId",
+      ],
+      relations: [
+        "eventProducts",
+        "eventHashtags",
+        "eventProducts.product.productHashtags",
+      ],
+    });
+
+    const images = await this.imagesRepository.find({
+      where: { targetId: id, type: RaffleType.EVENT },
     });
 
     if (!event) {
       return new CustomResponse<GetEventDto>(404, "E001", null);
     }
 
-    const eventDto = plainToInstance(GetEventDto, event);
+    const eventDto = plainToInstance(GetEventDto, {
+      ...event,
+      type: RaffleType.EVENT,
+      tagIds: event.eventHashtags.map((eh) => eh.hashtagId),
+      images: images.map((image) => image.url),
+      products: event.eventProducts.map((ep) => ({
+        id: ep.product.id,
+        name: ep.product.title,
+        imageUrl: ep.product.imageUrl,
+        tagIds: (ep.product.productHashtags || []).map((ph) => ph.hashtagId),
+      })),
+    });
 
     return new CustomResponse<GetEventDto>(200, "E002", eventDto);
   }

--- a/apps/back/apps/application/event/service/event.service.ts
+++ b/apps/back/apps/application/event/service/event.service.ts
@@ -172,7 +172,7 @@ export class EventService {
   async modifyEventById(
     id: number,
     dto: ModifyEventDto,
-  ): Promise<IResponse<any>> {
+  ): Promise<IResponse<void>> {
     const event = await this.eventRepository.findOne({
       where: { id, isDeleted: false },
       relations: ["eventProducts", "eventHashtags"],
@@ -234,7 +234,7 @@ export class EventService {
       }
     }
 
-    return new CustomResponse<any>(200, "E003", { id: event.id });
+    return new CustomResponse<any>(204, "E003", null);
   }
 
   async increaseViewCount(id: number): Promise<void> {

--- a/apps/back/apps/application/event/service/event.service.ts
+++ b/apps/back/apps/application/event/service/event.service.ts
@@ -233,7 +233,7 @@ export class EventService {
       }
     }
 
-    return new CustomResponse<any>(200, "E004", { id: event.id });
+    return new CustomResponse<any>(200, "E003", { id: event.id });
   }
 
   async increaseViewCount(id: number): Promise<void> {

--- a/apps/back/apps/application/event/service/event.service.ts
+++ b/apps/back/apps/application/event/service/event.service.ts
@@ -38,12 +38,12 @@ export class EventService {
     private readonly eventHashtagRepository: Repository<EventHashtag>,
   ) {}
 
+  // TODO: SignUp API 추가 되면 테스트 후 @CurrentUser()로 사용자 정보 가져와서 createUserId에 넣어주기
   @Transactional()
   async createEvent(
     dto: CreateEventDto,
   ): Promise<IResponse<CreateEventResultDto>> {
     // 이벤트 생성
-    // TODO: SignUp API 추가 되면 테스트 후 @CurrentUser()로 사용자 정보 가져와서 createUserId에 넣어주기
     const event = this.eventRepository.create({
       ...dto,
       thumbnail: dto.images[0],
@@ -164,49 +164,6 @@ export class EventService {
     });
 
     return new CustomResponse<GetEventDto>(200, "E002", eventDto);
-  }
-
-  // 이벤트 삭제
-  @Transactional()
-  async deleteEventById(id: number): Promise<IResponse<null>> {
-    const event = await this.eventRepository.findOne({
-      where: { id },
-      relations: ["eventProducts", "eventHashtags"],
-    });
-
-    if (!event) {
-      return new CustomResponse<null>(404, "E001", null);
-    }
-
-    const now = new Date();
-
-    for (const eventProduct of event.eventProducts) {
-      eventProduct.deletedAt = now;
-      eventProduct.isDeleted = true;
-      await this.eventProductRepository.save(eventProduct);
-    }
-
-    for (const eventHashtag of event.eventHashtags) {
-      eventHashtag.deletedAt = now;
-      eventHashtag.isDeleted = true;
-      await this.eventHashtagRepository.save(eventHashtag);
-    }
-
-    const images = await this.imagesRepository.find({
-      where: { targetId: id, type: RaffleType.EVENT },
-    });
-
-    for (const image of images) {
-      image.deletedAt = now;
-      image.isDeleted = true;
-      await this.imagesRepository.save(image);
-    }
-
-    event.deletedAt = now;
-    event.isDeleted = true;
-    await this.eventRepository.save(event);
-
-    return new CustomResponse<null>(204, "E003", null);
   }
 
   // 이벤트 수정

--- a/apps/back/apps/application/event/service/event.service.ts
+++ b/apps/back/apps/application/event/service/event.service.ts
@@ -30,6 +30,8 @@ export class EventService {
     private readonly productRepository: Repository<Product>,
     @InjectRepository(Images)
     private readonly imagesRepository: Repository<Images>,
+    @InjectRepository(Hashtag)
+    private readonly hashtagRepository: Repository<Hashtag>,
     @InjectRepository(ProductHashtag)
     private readonly productHashtagRepository: Repository<ProductHashtag>,
     @InjectRepository(EventProduct)
@@ -151,10 +153,14 @@ export class EventService {
       throw new ResourceNotFoundException("이벤트를 찾을 수 없습니다.", "E001");
     }
 
+    const hashtags = await this.hashtagRepository.findByIds(
+      event.eventHashtags.map((eh) => eh.hashtagId),
+    );
+
     const eventDto = plainToInstance(GetEventDto, {
       ...event,
       type: RaffleType.EVENT,
-      tagIds: event.eventHashtags.map((eh) => eh.hashtagId),
+      tags: hashtags.map((hashtag) => hashtag.name),
       images: images.map((image) => image.url),
       products: event.eventProducts.map((ep) => ({
         id: ep.product.id,

--- a/apps/back/apps/application/event/service/event.service.ts
+++ b/apps/back/apps/application/event/service/event.service.ts
@@ -162,4 +162,8 @@ export class EventService {
 
     return new CustomResponse<null>(204, "E003", null);
   }
+
+  async increaseViewCount(id: number): Promise<void> {
+    await this.eventRepository.increment({ id }, "viewCount", 1);
+  }
 }

--- a/apps/back/apps/application/event/service/event.service.ts
+++ b/apps/back/apps/application/event/service/event.service.ts
@@ -19,6 +19,7 @@ import { RaffleType } from "apps/domain/common/enum/raffle.enum";
 import { ProductHashtag } from "apps/domain/product/product-hashtag.entity";
 import { GetEventDto } from "apps/application/event/dto/response/get-event.dto";
 import { ModifyEventDto } from "apps/application/event/dto/request/modify-event.dto";
+import { ResourceNotFoundException } from "apps/infrastructure/error";
 
 @Injectable()
 export class EventService {
@@ -147,7 +148,7 @@ export class EventService {
     });
 
     if (!event) {
-      return new CustomResponse<GetEventDto>(404, "E001", null);
+      throw new ResourceNotFoundException("이벤트를 찾을 수 없습니다.", "E001");
     }
 
     const eventDto = plainToInstance(GetEventDto, {
@@ -178,7 +179,7 @@ export class EventService {
     });
 
     if (!event) {
-      return new CustomResponse<any>(404, "E001", null);
+      throw new ResourceNotFoundException("이벤트를 찾을 수 없습니다.", "E001");
     }
 
     // 이벤트 데이터 업데이트

--- a/apps/back/apps/application/product/dto/request/add-product.dto.ts
+++ b/apps/back/apps/application/product/dto/request/add-product.dto.ts
@@ -1,11 +1,12 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsArray, IsInt, IsString } from "class-validator";
+import { IsArray, IsInt, IsNotEmpty, IsString } from "class-validator";
 
 export class AddProductDto {
   @ApiProperty({
     example: "상품명",
     description: "상품명",
   })
+  @IsNotEmpty()
   @IsString()
   title: string;
 
@@ -13,6 +14,7 @@ export class AddProductDto {
     example: "이미지 URL",
     description: "이미지 URL",
   })
+  @IsNotEmpty()
   @IsString()
   imageUrl: string;
 
@@ -20,6 +22,7 @@ export class AddProductDto {
     example: [1, 2],
     description: "태그 ID",
   })
+  @IsNotEmpty()
   @IsInt({ each: true })
   @IsArray()
   tagIds: number[];

--- a/apps/back/apps/application/product/dto/request/add-product.dto.ts
+++ b/apps/back/apps/application/product/dto/request/add-product.dto.ts
@@ -1,12 +1,11 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsArray, IsInt, IsNotEmpty, IsString } from "class-validator";
+import { IsArray, IsInt, IsString } from "class-validator";
 
 export class AddProductDto {
   @ApiProperty({
     example: "상품명",
     description: "상품명",
   })
-  @IsNotEmpty()
   @IsString()
   title: string;
 
@@ -14,7 +13,6 @@ export class AddProductDto {
     example: "이미지 URL",
     description: "이미지 URL",
   })
-  @IsNotEmpty()
   @IsString()
   imageUrl: string;
 
@@ -22,7 +20,6 @@ export class AddProductDto {
     example: [1, 2],
     description: "태그 ID",
   })
-  @IsNotEmpty()
   @IsInt({ each: true })
   @IsArray()
   tagIds: number[];

--- a/apps/back/apps/application/product/dto/request/add-product.dto.ts
+++ b/apps/back/apps/application/product/dto/request/add-product.dto.ts
@@ -1,0 +1,26 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsArray, IsInt, IsString } from "class-validator";
+
+export class AddProductDto {
+  @ApiProperty({
+    example: "상품명",
+    description: "상품명",
+  })
+  @IsString()
+  title: string;
+
+  @ApiProperty({
+    example: "이미지 URL",
+    description: "이미지 URL",
+  })
+  @IsString()
+  imageUrl: string;
+
+  @ApiProperty({
+    example: [1, 2],
+    description: "태그 ID",
+  })
+  @IsInt({ each: true })
+  @IsArray()
+  tagIds: number[];
+}

--- a/apps/back/apps/application/product/dto/request/get-product.dto.ts
+++ b/apps/back/apps/application/product/dto/request/get-product.dto.ts
@@ -1,0 +1,29 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsArray, IsInt, IsNotEmpty, IsString } from "class-validator";
+
+export class GetProductDto {
+  @ApiProperty({
+    example: "상품명",
+    description: "상품명",
+  })
+  @IsNotEmpty()
+  @IsString()
+  title: string;
+
+  @ApiProperty({
+    example: "이미지 URL",
+    description: "이미지 URL",
+  })
+  @IsNotEmpty()
+  @IsString()
+  imageUrl: string;
+
+  @ApiProperty({
+    example: [1, 2],
+    description: "태그 ID",
+  })
+  @IsNotEmpty()
+  @IsInt({ each: true })
+  @IsArray()
+  tagIds: number[];
+}

--- a/apps/back/apps/application/product/dto/request/get-product.dto.ts
+++ b/apps/back/apps/application/product/dto/request/get-product.dto.ts
@@ -1,12 +1,11 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsArray, IsInt, IsNotEmpty, IsString } from "class-validator";
+import { IsArray, IsInt, IsString } from "class-validator";
 
 export class GetProductDto {
   @ApiProperty({
     example: "상품명",
     description: "상품명",
   })
-  @IsNotEmpty()
   @IsString()
   title: string;
 
@@ -14,7 +13,6 @@ export class GetProductDto {
     example: "이미지 URL",
     description: "이미지 URL",
   })
-  @IsNotEmpty()
   @IsString()
   imageUrl: string;
 
@@ -22,7 +20,6 @@ export class GetProductDto {
     example: [1, 2],
     description: "태그 ID",
   })
-  @IsNotEmpty()
   @IsInt({ each: true })
   @IsArray()
   tagIds: number[];

--- a/apps/back/apps/domain/common/enum/raffle.enum.ts
+++ b/apps/back/apps/domain/common/enum/raffle.enum.ts
@@ -1,4 +1,5 @@
 export enum RaffleType {
   RAFFLE = "RAFFLE",
   EVENT = "EVENT",
+  PRODUCT = "PRODUCT",
 }

--- a/apps/back/apps/front-api/src/app.module.ts
+++ b/apps/back/apps/front-api/src/app.module.ts
@@ -13,6 +13,7 @@ import { envValidationSchema } from "env.config";
 import { AuthController } from "./auth/auth.controller";
 import { HealthController } from "./health/health.controller";
 import { CardController } from "apps/front-api/src/card/card.controller";
+import {EventController} from "apps/front-api/src/event/event.controller";
 
 @Module({
   imports: [
@@ -40,7 +41,7 @@ import { CardController } from "apps/front-api/src/card/card.controller";
       useClass: HttpExceptionFilter,
     },
   ],
-  controllers: [AuthController, HealthController, CardController],
+  controllers: [AuthController, HealthController, EventController, CardController],
 })
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {

--- a/apps/back/apps/front-api/src/event/event.controller.ts
+++ b/apps/back/apps/front-api/src/event/event.controller.ts
@@ -1,8 +1,48 @@
-import {Controller} from "@nestjs/common";
-import {EventService} from "apps/application/event/service/event.service";
+import { Body, Controller, Get, Param, Post } from "@nestjs/common";
+import { EventService } from "apps/application/event/service/event.service";
+import { CreateEventDto } from "apps/application/event/dto/request/create-event.dto";
+import {
+  IResponse,
+  ResponseDto,
+} from "apps/application/common/response/response";
+import { CreateEventResultDto } from "apps/application/event/dto/response/create-event-result.dto";
+import { ApiOkResponse, ApiOperation } from "@nestjs/swagger";
+import { Public } from "apps/application/common/auth/public.decorator";
+import { GetEventDto } from "apps/application/event/dto/response/get-event.dto";
 
 @Controller("events")
 export class EventController {
-    constructor(private readonly eventService: EventService) {
-    }
+  constructor(private readonly eventService: EventService) {}
+
+  // TODO: @CurrentUser()로 사용자 정보 가져와서 createUserId에 넣어주기, @Public() 제거
+  @ApiOperation({
+    summary: "이벤트 생성",
+    operationId: "createEvent",
+    tags: ["event"],
+  })
+  @ApiOkResponse({
+    type: ResponseDto(CreateEventResultDto, "CreateEventResult"),
+  })
+  @Post()
+  @Public()
+  async createEvent(
+    @Body() dto: CreateEventDto,
+    // @CurrentUser() user: any,
+  ): Promise<IResponse<CreateEventResultDto>> {
+    return this.eventService.createEvent(dto);
+  }
+
+  @ApiOperation({
+    summary: "이벤트 조회",
+    operationId: "getEventById",
+    tags: ["event"],
+  })
+  @ApiOkResponse({
+    type: ResponseDto(GetEventDto, "GetEvent"),
+  })
+  @Get(":id")
+  @Public()
+  async getEventById(@Param("id") id: number): Promise<IResponse<GetEventDto>> {
+    return this.eventService.getEventById(id);
+  }
 }

--- a/apps/back/apps/front-api/src/event/event.controller.ts
+++ b/apps/back/apps/front-api/src/event/event.controller.ts
@@ -1,0 +1,8 @@
+import {Controller} from "@nestjs/common";
+import {EventService} from "apps/application/event/service/event.service";
+
+@Controller("events")
+export class EventController {
+    constructor(private readonly eventService: EventService) {
+    }
+}

--- a/apps/back/apps/front-api/src/event/event.controller.ts
+++ b/apps/back/apps/front-api/src/event/event.controller.ts
@@ -5,6 +5,7 @@ import {
   Get,
   Param,
   Post,
+  Put,
   UseInterceptors,
 } from "@nestjs/common";
 import { EventService } from "apps/application/event/service/event.service";
@@ -18,6 +19,7 @@ import { ApiOkResponse, ApiOperation } from "@nestjs/swagger";
 import { Public } from "apps/application/common/auth/public.decorator";
 import { GetEventDto } from "apps/application/event/dto/response/get-event.dto";
 import { EventViewCountInterceptor } from "apps/application/event/interceptor/event-view-count.interceptor";
+import { ModifyEventDto } from "apps/application/event/dto/request/modify-event.dto";
 
 @Controller("events")
 export class EventController {
@@ -65,5 +67,19 @@ export class EventController {
   @Public()
   async deleteEventById(@Param("id") id: number): Promise<IResponse<null>> {
     return this.eventService.deleteEventById(id);
+  }
+
+  @ApiOperation({
+    summary: "이벤트 수정",
+    operationId: "modifyEvent",
+    tags: ["event"],
+  })
+  @Put(":id")
+  @Public()
+  async modifyEventById(
+    @Param("id") id: number,
+    @Body() dto: ModifyEventDto,
+  ): Promise<IResponse<any>> {
+    return this.eventService.modifyEventById(id, dto);
   }
 }

--- a/apps/back/apps/front-api/src/event/event.controller.ts
+++ b/apps/back/apps/front-api/src/event/event.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, Delete, Get, Param, Post } from "@nestjs/common";
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  UseInterceptors,
+} from "@nestjs/common";
 import { EventService } from "apps/application/event/service/event.service";
 import { CreateEventDto } from "apps/application/event/dto/request/create-event.dto";
 import {
@@ -9,6 +17,7 @@ import { CreateEventResultDto } from "apps/application/event/dto/response/create
 import { ApiOkResponse, ApiOperation } from "@nestjs/swagger";
 import { Public } from "apps/application/common/auth/public.decorator";
 import { GetEventDto } from "apps/application/event/dto/response/get-event.dto";
+import { EventViewCountInterceptor } from "apps/application/event/interceptor/event-view-count.interceptor";
 
 @Controller("events")
 export class EventController {
@@ -42,6 +51,7 @@ export class EventController {
   })
   @Get(":id")
   @Public()
+  @UseInterceptors(EventViewCountInterceptor)
   async getEventById(@Param("id") id: number): Promise<IResponse<GetEventDto>> {
     return this.eventService.getEventById(id);
   }

--- a/apps/back/apps/front-api/src/event/event.controller.ts
+++ b/apps/back/apps/front-api/src/event/event.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, Post } from "@nestjs/common";
+import { Body, Controller, Delete, Get, Param, Post } from "@nestjs/common";
 import { EventService } from "apps/application/event/service/event.service";
 import { CreateEventDto } from "apps/application/event/dto/request/create-event.dto";
 import {
@@ -44,5 +44,16 @@ export class EventController {
   @Public()
   async getEventById(@Param("id") id: number): Promise<IResponse<GetEventDto>> {
     return this.eventService.getEventById(id);
+  }
+
+  @ApiOperation({
+    summary: "이벤트 삭제",
+    operationId: "deleteEvent",
+    tags: ["event"],
+  })
+  @Delete(":id")
+  @Public()
+  async deleteEventById(@Param("id") id: number): Promise<IResponse<null>> {
+    return this.eventService.deleteEventById(id);
   }
 }

--- a/apps/back/apps/front-api/src/event/event.controller.ts
+++ b/apps/back/apps/front-api/src/event/event.controller.ts
@@ -1,7 +1,6 @@
 import {
   Body,
   Controller,
-  Delete,
   Get,
   Param,
   Post,
@@ -56,17 +55,6 @@ export class EventController {
   @UseInterceptors(EventViewCountInterceptor)
   async getEventById(@Param("id") id: number): Promise<IResponse<GetEventDto>> {
     return this.eventService.getEventById(id);
-  }
-
-  @ApiOperation({
-    summary: "이벤트 삭제",
-    operationId: "deleteEvent",
-    tags: ["event"],
-  })
-  @Delete(":id")
-  @Public()
-  async deleteEventById(@Param("id") id: number): Promise<IResponse<null>> {
-    return this.eventService.deleteEventById(id);
   }
 
   @ApiOperation({


### PR DESCRIPTION
## 📖 개요
- 이벤트 생성 API 구현
- 이벤트 수정 API 구현
- 이벤트 개별 조회 API 구현

## 💻 작업사항
- Interceptor를 통해 이벤트 개별 조회 API가 호출 될 때 조회수 1 증가하도록 구현
- 이벤트를 생성할 때, 해당하는 images를 테이블에 삽입
- 상품에 대한 이미지의 구별을 위해 `raffle.enum.ts` 에 PRODUCT 추가
- 응모하기 API의 호출을 위해 이벤트 개별 조회 시 type(RAFFLE or EVENT)도 함께 전달

- API의 테스트를 위해 임시로 `@Public` 사용, 추후 #17 머지 후 User에 대한 처리해줄 예정

## 💡 작성한 이슈 외에 작업한 사항
- 없습니다

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
