### PR TITLE
feat: 카드 도메인 API 구현

### DIFF
--- a/apps/back/apps/application/application.module.ts
+++ b/apps/back/apps/application/application.module.ts
@@ -1,10 +1,10 @@
 import { Module } from "@nestjs/common";
-
 import { AuthModule } from "./auth/auth.module";
+import { CardModule } from "apps/application/card/card.module";
 
 @Module({
-  imports: [AuthModule],
+  imports: [AuthModule, CardModule],
   providers: [],
-  exports: [AuthModule],
+  exports: [AuthModule, CardModule],
 })
 export class ApplicationModule {}

--- a/apps/back/apps/application/card/card.module.ts
+++ b/apps/back/apps/application/card/card.module.ts
@@ -1,10 +1,8 @@
 import { Module } from "@nestjs/common";
 import { CardService } from "apps/application/card/service/card.service";
-import { CardController } from "apps/front-api/src/card/card.controller";
 
 @Module({
   providers: [CardService],
   exports: [CardService],
-  controllers: [CardController],
 })
 export class CardModule {}

--- a/apps/back/apps/application/card/card.module.ts
+++ b/apps/back/apps/application/card/card.module.ts
@@ -1,0 +1,8 @@
+import { Module } from "@nestjs/common";
+import { CardService } from "apps/application/card/service/card.service";
+
+@Module({
+  providers: [CardService],
+  exports: [CardService],
+})
+export class CardModule {}

--- a/apps/back/apps/application/card/card.module.ts
+++ b/apps/back/apps/application/card/card.module.ts
@@ -1,8 +1,10 @@
 import { Module } from "@nestjs/common";
 import { CardService } from "apps/application/card/service/card.service";
+import { CardController } from "apps/front-api/src/card/card.controller";
 
 @Module({
   providers: [CardService],
   exports: [CardService],
+  controllers: [CardController],
 })
 export class CardModule {}

--- a/apps/back/apps/application/card/dto/request/create-card.dto.ts
+++ b/apps/back/apps/application/card/dto/request/create-card.dto.ts
@@ -1,0 +1,36 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsBoolean, IsString } from "class-validator";
+
+export class CreateCardDto {
+  @ApiProperty({ example: "카드 이름", description: "카드 이름" })
+  @IsString()
+  cardName: string;
+
+  @ApiProperty({ example: "KB", description: "카드사 코드" })
+  @IsString()
+  cardCode: string;
+
+  @ApiProperty({ example: "1234-5678-9012-3456", description: "카드 번호" })
+  @IsString()
+  cardNumber: string;
+
+  @ApiProperty({ example: "12", description: "카드 비밀번호 앞 2자리" })
+  @IsString()
+  cardPassword: string;
+
+  @ApiProperty({ example: "08/24", description: "카드 만료일" })
+  @IsString()
+  cardExpirationDate: string;
+
+  @ApiProperty({ example: "billing_key", description: "카드 빌링키" })
+  @IsString()
+  billingKey: string;
+
+  @ApiProperty({
+    example: true,
+    description: "주사용 카드 여부",
+    default: false,
+  })
+  @IsBoolean()
+  isDefault: boolean;
+}

--- a/apps/back/apps/application/card/dto/request/set-default-card.dto.ts
+++ b/apps/back/apps/application/card/dto/request/set-default-card.dto.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsBoolean } from "class-validator";
+
+export class SetDefaultCardDto {
+  @ApiProperty({ example: true, description: "주사용 카드 여부" })
+  @IsBoolean()
+  isDefault: boolean;
+}

--- a/apps/back/apps/application/card/dto/response/create-card-result.dto.ts
+++ b/apps/back/apps/application/card/dto/response/create-card-result.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class CreateCardResultDto {
+  @ApiProperty({ example: 1, description: "카드 ID" })
+  id: number;
+
+  @ApiProperty({ example: "My Card", description: "카드 이름" })
+  cardName: string;
+
+  @ApiProperty({ example: "KB", description: "카드사 코드" })
+  cardCode: string;
+
+  @ApiProperty({ example: "1234-5678-9012-3456", description: "카드 번호" })
+  cardNumber: string;
+
+  @ApiProperty({ example: "08/24", description: "카드 만료일" })
+  cardExpirationDate: string;
+
+  @ApiProperty({ example: "billing_key", description: "카드 빌링키" })
+  billingKey: string;
+
+  @ApiProperty({
+    example: true,
+    description: "주사용 카드 여부",
+    default: false,
+  })
+  isDefault: boolean;
+}

--- a/apps/back/apps/application/card/dto/response/get-card.dto.ts
+++ b/apps/back/apps/application/card/dto/response/get-card.dto.ts
@@ -1,0 +1,25 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsInt } from "class-validator";
+
+export class CardDetailDto {
+  @ApiProperty({ example: 1, description: "카드 ID" })
+  @IsInt()
+  id: number;
+
+  @ApiProperty({ example: "국민", description: "카드사 코드" })
+  cardCode: string;
+
+  @ApiProperty({
+    example: "**** **** **** 1234",
+    description: "마스킹 처리된 카드 번호",
+  })
+  cardNumber: string;
+
+  @ApiProperty({ example: true, description: "주사용 카드 여부" })
+  isDefault: boolean;
+}
+
+export class GetCardDto {
+  @ApiProperty({ type: [CardDetailDto], description: "카드 목록" })
+  items: CardDetailDto[];
+}

--- a/apps/back/apps/application/card/dto/response/get-card.dto.ts
+++ b/apps/back/apps/application/card/dto/response/get-card.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from "@nestjs/swagger";
+import { Type } from "class-transformer";
 
 export class CardDetailDto {
   @ApiProperty({ example: 1, description: "카드 ID" })
@@ -19,5 +20,6 @@ export class CardDetailDto {
 
 export class GetCardDto {
   @ApiProperty({ type: [CardDetailDto], description: "카드 목록" })
+  @Type(() => CardDetailDto)
   items: CardDetailDto[];
 }

--- a/apps/back/apps/application/card/dto/response/get-card.dto.ts
+++ b/apps/back/apps/application/card/dto/response/get-card.dto.ts
@@ -1,9 +1,7 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsInt } from "class-validator";
 
 export class CardDetailDto {
   @ApiProperty({ example: 1, description: "카드 ID" })
-  @IsInt()
   id: number;
 
   @ApiProperty({ example: "국민", description: "카드사 코드" })

--- a/apps/back/apps/application/card/dto/response/set-default-card-result.dto.ts
+++ b/apps/back/apps/application/card/dto/response/set-default-card-result.dto.ts
@@ -1,0 +1,27 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class SetDefaultCardResultDto {
+  @ApiProperty({ example: 1, description: "카드 ID" })
+  id: number;
+
+  @ApiProperty({ example: "My Card", description: "카드 이름" })
+  cardName: string;
+
+  @ApiProperty({ example: "KB", description: "카드사 코드" })
+  cardCode: string;
+
+  @ApiProperty({ example: "1234-5678-9012-3456", description: "카드 번호" })
+  cardNumber: string;
+
+  @ApiProperty({ example: "08/24", description: "카드 만료일" })
+  cardExpirationDate: string;
+
+  @ApiProperty({ example: "billing_key", description: "카드 빌링키" })
+  billingKey: string;
+
+  @ApiProperty({
+    example: true,
+    description: "주사용 카드 여부",
+  })
+  isDefault: boolean;
+}

--- a/apps/back/apps/application/card/service/card.service.ts
+++ b/apps/back/apps/application/card/service/card.service.ts
@@ -14,6 +14,8 @@ import {
   CardDetailDto,
   GetCardDto,
 } from "apps/application/card/dto/response/get-card.dto";
+import { SetDefaultCardDto } from "apps/application/card/dto/request/set-default-card.dto";
+import { SetDefaultCardResultDto } from "apps/application/card/dto/response/set-default-card-result.dto";
 
 @Injectable()
 export class CardService {
@@ -83,5 +85,32 @@ export class CardService {
     await this.cardRepository.save(card);
 
     return new CustomResponse<null>(204, "C003", null);
+  }
+
+  // 주사용 카드 변경
+  async setDefaultCard(
+    id: number,
+    dto: SetDefaultCardDto
+  ): Promise<IResponse<SetDefaultCardResultDto>> {
+    const card = await this.cardRepository.findOne({ where: { id } });
+
+    card.isDefault = dto.isDefault;
+    await this.cardRepository.save(card);
+
+    const setDefaultCardResultDto = plainToInstance(SetDefaultCardResultDto, {
+      id: card.id,
+      cardName: card.cardName,
+      cardCode: card.cardCode,
+      cardNumber: card.cardNumber.replace(/.(?=.{4})/g, "*"),
+      cardExpirationDate: card.cardExpirationDate,
+      billingKey: card.billingKey,
+      isDefault: card.isDefault,
+    });
+
+    return new CustomResponse<SetDefaultCardResultDto>(
+      200,
+      "C004",
+      setDefaultCardResultDto
+    );
   }
 }

--- a/apps/back/apps/application/card/service/card.service.ts
+++ b/apps/back/apps/application/card/service/card.service.ts
@@ -6,7 +6,10 @@ import {
   IResponse,
 } from "apps/application/common/response/response";
 import { Card } from "apps/domain/card/card.entity";
+import { CreateCardDto } from "apps/application/card/dto/request/create-card.dto";
+import { CreateCardResultDto } from "apps/application/card/dto/response/create-card-result.dto";
 import { Transactional } from "typeorm-transactional";
+import { plainToInstance } from "class-transformer";
 
 @Injectable()
 export class CardService {
@@ -14,4 +17,35 @@ export class CardService {
     @InjectRepository(Card)
     private readonly cardRepository: Repository<Card>
   ) {}
+
+  @Transactional()
+  async createCard(
+    dto: CreateCardDto
+  ): Promise<IResponse<CreateCardResultDto>> {
+    // 카드 등록
+    // TODO: SignUp API 추가되면, @CurrentUser()로 사용자 정보 가져오기
+    const card = this.cardRepository.create({
+      ...dto,
+      userId: 1,
+    });
+
+    await this.cardRepository.save(card);
+
+    // 카드 등록 결과 DTO 생성
+    const createCardResultDto = plainToInstance(CreateCardResultDto, {
+      id: card.id,
+      cardName: card.cardName,
+      cardCode: card.cardCode,
+      cardNumber: card.cardNumber,
+      cardExpirationDate: card.cardExpirationDate,
+      billingKey: card.billingKey,
+      isDefault: card.isDefault,
+    });
+
+    return new CustomResponse<CreateCardResultDto>(
+      200,
+      "C001",
+      createCardResultDto
+    );
+  }
 }

--- a/apps/back/apps/application/card/service/card.service.ts
+++ b/apps/back/apps/application/card/service/card.service.ts
@@ -17,6 +17,7 @@ import {
 import { SetDefaultCardDto } from "apps/application/card/dto/request/set-default-card.dto";
 import { SetDefaultCardResultDto } from "apps/application/card/dto/response/set-default-card-result.dto";
 
+// TODO: Error 처리는 추후에 통일
 @Injectable()
 export class CardService {
   constructor(
@@ -79,6 +80,10 @@ export class CardService {
   // 카드 삭제
   async deleteCard(id: number): Promise<IResponse<null>> {
     const card = await this.cardRepository.findOne({ where: { id } });
+
+    if (!card) {
+      return new CustomResponse<null>(404, "C005", null);
+    }
 
     card.deletedAt = new Date();
     card.isDeleted = true;

--- a/apps/back/apps/application/card/service/card.service.ts
+++ b/apps/back/apps/application/card/service/card.service.ts
@@ -97,6 +97,13 @@ export class CardService {
     id: number,
     dto: SetDefaultCardDto
   ): Promise<IResponse<SetDefaultCardResultDto>> {
+    await this.cardRepository
+      .createQueryBuilder()
+      .update(Card)
+      .set({ isDefault: false })
+      .where({ isDefault: true })
+      .execute();
+
     const card = await this.cardRepository.findOne({ where: { id } });
 
     card.isDefault = dto.isDefault;

--- a/apps/back/apps/application/card/service/card.service.ts
+++ b/apps/back/apps/application/card/service/card.service.ts
@@ -10,6 +10,10 @@ import { CreateCardDto } from "apps/application/card/dto/request/create-card.dto
 import { CreateCardResultDto } from "apps/application/card/dto/response/create-card-result.dto";
 import { Transactional } from "typeorm-transactional";
 import { plainToInstance } from "class-transformer";
+import {
+  CardDetailDto,
+  GetCardDto,
+} from "apps/application/card/dto/response/get-card.dto";
 
 @Injectable()
 export class CardService {
@@ -47,5 +51,26 @@ export class CardService {
       "C001",
       createCardResultDto
     );
+  }
+
+  // 카드 조회
+  // TODO: SignUp API 추가되면, @CurrentUser()로 사용자 정보 가져오기
+  async getCards(userId: number): Promise<IResponse<GetCardDto>> {
+    const cards = await this.cardRepository.find({ where: { userId: userId } });
+
+    const items = cards.map((card) =>
+      plainToInstance(CardDetailDto, {
+        id: card.id,
+        cardCode: card.cardCode,
+        cardNumber: card.cardNumber.replace(/.(?=.{4})/g, "*"),
+        isDefault: card.isDefault,
+      })
+    );
+
+    // 카드 배열 DTO 생성
+    const cardListItemDto = new GetCardDto();
+    cardListItemDto.items = items;
+
+    return new CustomResponse<GetCardDto>(200, "C002", cardListItemDto);
   }
 }

--- a/apps/back/apps/application/card/service/card.service.ts
+++ b/apps/back/apps/application/card/service/card.service.ts
@@ -73,4 +73,15 @@ export class CardService {
 
     return new CustomResponse<GetCardDto>(200, "C002", cardListItemDto);
   }
+
+  // 카드 삭제
+  async deleteCard(id: number): Promise<IResponse<null>> {
+    const card = await this.cardRepository.findOne({ where: { id } });
+
+    card.deletedAt = new Date();
+    card.isDeleted = true;
+    await this.cardRepository.save(card);
+
+    return new CustomResponse<null>(204, "C003", null);
+  }
 }

--- a/apps/back/apps/application/card/service/card.service.ts
+++ b/apps/back/apps/application/card/service/card.service.ts
@@ -106,6 +106,10 @@ export class CardService {
 
     const card = await this.cardRepository.findOne({ where: { id } });
 
+    if (!card) {
+      return new CustomResponse<null>(404, "C005", null);
+    }
+
     card.isDefault = dto.isDefault;
     await this.cardRepository.save(card);
 

--- a/apps/back/apps/application/card/service/card.service.ts
+++ b/apps/back/apps/application/card/service/card.service.ts
@@ -42,7 +42,7 @@ export class CardService {
       id: card.id,
       cardName: card.cardName,
       cardCode: card.cardCode,
-      cardNumber: card.cardNumber,
+      cardNumber: card.cardNumber.replace(/.(?=.{4})/g, "*"),
       cardExpirationDate: card.cardExpirationDate,
       billingKey: card.billingKey,
       isDefault: card.isDefault,

--- a/apps/back/apps/application/card/service/card.service.ts
+++ b/apps/back/apps/application/card/service/card.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import {
+  CustomResponse,
+  IResponse,
+} from "apps/application/common/response/response";
+import { Card } from "apps/domain/card/card.entity";
+import { Transactional } from "typeorm-transactional";
+
+@Injectable()
+export class CardService {
+  constructor(
+    @InjectRepository(Card)
+    private readonly cardRepository: Repository<Card>
+  ) {}
+}

--- a/apps/back/apps/domain/card/card.entity.ts
+++ b/apps/back/apps/domain/card/card.entity.ts
@@ -13,14 +13,17 @@ export class Card extends DefaultEntity {
   @Column({ comment: "카드 번호" })
   cardNumber: string;
 
+  @Column({ comment: "비밀번호" })
+  cardPassword: string;
+
   @Column({ comment: "카드 만료일" })
   cardExpirationDate: string;
 
   @Column({ comment: "카드 빌링키" })
-  cardBillingKey: string;
+  billingKey: string;
 
   @Column({ comment: "주사용 카드 여부" })
-  isDefault: boolean;
+  isDefault: boolean = false;
 
   @Column({ comment: "사용자 ID" })
   userId: number;

--- a/apps/back/apps/domain/card/card.entity.ts
+++ b/apps/back/apps/domain/card/card.entity.ts
@@ -22,7 +22,7 @@ export class Card extends DefaultEntity {
   @Column({ comment: "카드 빌링키" })
   billingKey: string;
 
-  @Column({ comment: "주사용 카드 여부" })
+  @Column({ comment: "주사용 카드 여부", default: false })
   isDefault: boolean = false;
 
   @Column({ comment: "사용자 ID" })

--- a/apps/back/apps/front-api/src/app.module.ts
+++ b/apps/back/apps/front-api/src/app.module.ts
@@ -12,6 +12,7 @@ import { envValidationSchema } from "env.config";
 
 import { AuthController } from "./auth/auth.controller";
 import { HealthController } from "./health/health.controller";
+import { CardController } from "apps/front-api/src/card/card.controller";
 
 @Module({
   imports: [
@@ -39,7 +40,7 @@ import { HealthController } from "./health/health.controller";
       useClass: HttpExceptionFilter,
     },
   ],
-  controllers: [AuthController, HealthController],
+  controllers: [AuthController, HealthController, CardController],
 })
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {

--- a/apps/back/apps/front-api/src/card/card.controller.ts
+++ b/apps/back/apps/front-api/src/card/card.controller.ts
@@ -1,0 +1,7 @@
+import { Controller } from "@nestjs/common";
+import { CardService } from "apps/application/card/service/card.service";
+
+@Controller("users/me/cards")
+export class CardController {
+  constructor(private readonly cardServie: CardService) {}
+}

--- a/apps/back/apps/front-api/src/card/card.controller.ts
+++ b/apps/back/apps/front-api/src/card/card.controller.ts
@@ -1,7 +1,34 @@
-import { Controller } from "@nestjs/common";
+import { Controller, Post, Body } from "@nestjs/common";
 import { CardService } from "apps/application/card/service/card.service";
+import { CreateCardDto } from "apps/application/card/dto/request/create-card.dto";
+import { ApiOperation, ApiOkResponse } from "@nestjs/swagger";
+import {
+  IResponse,
+  ResponseDto,
+} from "apps/application/common/response/response";
+import { CreateCardResultDto } from "apps/application/card/dto/response/create-card-result.dto";
+import { Public } from "apps/application/common/auth/public.decorator";
+// import { CurrentUser } from "apps/application/common/auth/current-user.decorator";
 
 @Controller("users/me/cards")
 export class CardController {
-  constructor(private readonly cardServie: CardService) {}
+  constructor(private readonly cardService: CardService) {}
+
+  // TODO: @CurrentUser()로 사용자 정보 가져오기, @Public() 제거하기
+  @ApiOperation({
+    summary: "카드 생성",
+    operationId: "createCard",
+    tags: ["card"],
+  })
+  @ApiOkResponse({
+    type: ResponseDto(CreateCardResultDto, "CreateCardResult"),
+  })
+  @Post()
+  @Public()
+  async createCard(
+    @Body() dto: CreateCardDto
+    // @CurrentUser() user: User
+  ): Promise<IResponse<CreateCardResultDto>> {
+    return this.cardService.createCard(dto);
+  }
 }

--- a/apps/back/apps/front-api/src/card/card.controller.ts
+++ b/apps/back/apps/front-api/src/card/card.controller.ts
@@ -1,4 +1,12 @@
-import { Controller, Post, Body, Get, Param, Delete } from "@nestjs/common";
+import {
+  Controller,
+  Post,
+  Body,
+  Get,
+  Param,
+  Delete,
+  Patch,
+} from "@nestjs/common";
 import { CardService } from "apps/application/card/service/card.service";
 import { CreateCardDto } from "apps/application/card/dto/request/create-card.dto";
 import { ApiOperation, ApiOkResponse } from "@nestjs/swagger";
@@ -9,6 +17,8 @@ import {
 import { CreateCardResultDto } from "apps/application/card/dto/response/create-card-result.dto";
 import { Public } from "apps/application/common/auth/public.decorator";
 import { GetCardDto } from "apps/application/card/dto/response/get-card.dto";
+import { SetDefaultCardResultDto } from "apps/application/card/dto/response/set-default-card-result.dto";
+import { SetDefaultCardDto } from "apps/application/card/dto/request/set-default-card.dto";
 // import { CurrentUser } from "apps/application/common/auth/current-user.decorator";
 
 @Controller("users/me/cards")
@@ -59,5 +69,23 @@ export class CardController {
   @Public()
   async deleteCard(@Param("id") id: number): Promise<IResponse<null>> {
     return this.cardService.deleteCard(id);
+  }
+
+  // TODO: @Public() 제거하기
+  @ApiOperation({
+    summary: "주사용 카드 변경",
+    operationId: "setDefaultCard",
+    tags: ["card"],
+  })
+  @ApiOkResponse({
+    type: ResponseDto(SetDefaultCardResultDto, "SetDefaultCardResult"),
+  })
+  @Patch(":id")
+  @Public()
+  async setDefaultCard(
+    @Param("id") id: number,
+    @Body() dto: SetDefaultCardDto
+  ): Promise<IResponse<SetDefaultCardResultDto>> {
+    return this.cardService.setDefaultCard(id, dto);
   }
 }

--- a/apps/back/apps/front-api/src/card/card.controller.ts
+++ b/apps/back/apps/front-api/src/card/card.controller.ts
@@ -6,6 +6,7 @@ import {
   Param,
   Delete,
   Patch,
+  ParseIntPipe,
 } from "@nestjs/common";
 import { CardService } from "apps/application/card/service/card.service";
 import { CreateCardDto } from "apps/application/card/dto/request/create-card.dto";
@@ -67,7 +68,9 @@ export class CardController {
   })
   @Delete(":id")
   @Public()
-  async deleteCard(@Param("id") id: number): Promise<IResponse<null>> {
+  async deleteCard(
+    @Param("id", ParseIntPipe) id: number
+  ): Promise<IResponse<null>> {
     return this.cardService.deleteCard(id);
   }
 

--- a/apps/back/apps/front-api/src/card/card.controller.ts
+++ b/apps/back/apps/front-api/src/card/card.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body, Get } from "@nestjs/common";
+import { Controller, Post, Body, Get, Param, Delete } from "@nestjs/common";
 import { CardService } from "apps/application/card/service/card.service";
 import { CreateCardDto } from "apps/application/card/dto/request/create-card.dto";
 import { ApiOperation, ApiOkResponse } from "@nestjs/swagger";
@@ -47,5 +47,17 @@ export class CardController {
   async getCards() // @CurrentUser() user: User
   : Promise<IResponse<GetCardDto>> {
     return this.cardService.getCards(1);
+  }
+
+  // TODO: @Public() 제거하기
+  @ApiOperation({
+    summary: "카드 삭제",
+    operationId: "deleteCard",
+    tags: ["card"],
+  })
+  @Delete(":id")
+  @Public()
+  async deleteCard(@Param("id") id: number): Promise<IResponse<null>> {
+    return this.cardService.deleteCard(id);
   }
 }

--- a/apps/back/apps/front-api/src/card/card.controller.ts
+++ b/apps/back/apps/front-api/src/card/card.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body } from "@nestjs/common";
+import { Controller, Post, Body, Get } from "@nestjs/common";
 import { CardService } from "apps/application/card/service/card.service";
 import { CreateCardDto } from "apps/application/card/dto/request/create-card.dto";
 import { ApiOperation, ApiOkResponse } from "@nestjs/swagger";
@@ -8,6 +8,7 @@ import {
 } from "apps/application/common/response/response";
 import { CreateCardResultDto } from "apps/application/card/dto/response/create-card-result.dto";
 import { Public } from "apps/application/common/auth/public.decorator";
+import { GetCardDto } from "apps/application/card/dto/response/get-card.dto";
 // import { CurrentUser } from "apps/application/common/auth/current-user.decorator";
 
 @Controller("users/me/cards")
@@ -30,5 +31,21 @@ export class CardController {
     // @CurrentUser() user: User
   ): Promise<IResponse<CreateCardResultDto>> {
     return this.cardService.createCard(dto);
+  }
+
+  // TODO: @CurrentUser()로 사용자 정보 가져오기, @Public() 제거하기
+  @ApiOperation({
+    summary: "사용자 카드 목록 조회",
+    operationId: "getCards",
+    tags: ["card"],
+  })
+  @ApiOkResponse({
+    type: ResponseDto(GetCardDto, "GetCards"),
+  })
+  @Get()
+  @Public()
+  async getCards() // @CurrentUser() user: User
+  : Promise<IResponse<GetCardDto>> {
+    return this.cardService.getCards(1);
   }
 }


### PR DESCRIPTION
## 📖 개요

- 카드 등록 API 구현
- 카드 조회 API 구현
- 카드 삭제 API 구현
- 주사용 카드 변경 API 구현

## 💻 작업사항
- 카드 조회 시, 각 카드 정보는 마스킹 처리되도록 구현
- CardDetailDto는 개별 카드의 상세 정보를 나타내고, GetCardDto는 여러 개의 CardDetailDto를 배열 형태로 감싸 전체 카드 목록을 관리하고, API 응답 형식을 정의하는 데 사용
- API의 테스트를 위해 임시로 `@Public 사용`, 추후 #17 머지 후 User에 대한 처리해줄 예정

## 💡 작성한 이슈 외에 작업한 사항

- 없습니다

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
