### PR TITLE
feat: Raffle Card 컴포넌트 추가

### DIFF
--- a/packages/ui/src/ui/raffle-card/RaffleCard.mdx
+++ b/packages/ui/src/ui/raffle-card/RaffleCard.mdx
@@ -1,0 +1,40 @@
+import { Meta, Story, Controls, Canvas, Primary } from "@storybook/blocks";
+
+import * as stories from "./RaffleCard.stories";
+
+<Meta of={stories} />
+
+# Raffle Card
+
+`RaffleCard` 컴포넌트는 래플 상품 카드 컴포넌트입니다.
+
+---
+
+- [Overview](#overview)
+- [Props](#props)
+- [Usage](#usage)
+
+## Overview
+
+<Primary />
+
+## Props
+
+`endDate`가 없을 경우에는 마감되지 않은 래플로 간주합니다.<br/>
+`endDate`는 서버 응답으로 받아온 string 타입의 데이터입니다. 현재 시간과 비교하여 마감 여부를 결정합니다.
+
+<Controls />
+
+## Usage
+
+### Raffle Card
+
+래플 카드 사용 예시입니다.
+
+<Canvas of={stories.Default} meta={stories} />
+
+### Closed Raffle Card
+
+마감된 래플 카드 사용 예시입니다.
+
+<Canvas of={stories.Closed} meta={stories} />

--- a/packages/ui/src/ui/raffle-card/RaffleCard.stories.tsx
+++ b/packages/ui/src/ui/raffle-card/RaffleCard.stories.tsx
@@ -31,7 +31,16 @@ const meta: Meta<typeof RaffleCard> = {
   args: {
     name: "[Vans] 올드스쿨",
     price: "78,000",
-    hashtags: ["한정판", "Vans"],
+    hashtags: [
+      {
+        id: 1,
+        name: "한정판",
+      },
+      {
+        id: 2,
+        name: "Vans",
+      },
+    ],
     scrapCount: 3100,
     thumbnailUrl: "https://shorturl.at/HMedV",
     isBookmarked: true,
@@ -46,3 +55,26 @@ export const Default = Template.bind({});
 
 export const Closed = Template.bind({});
 Closed.args = { ...Default.args, endDate: "2024-08-02 23:20:59" };
+
+export const TagOverflow = Template.bind({});
+TagOverflow.args = {
+  ...Default.args,
+  hashtags: [
+    {
+      id: 1,
+      name: "한정판",
+    },
+    {
+      id: 2,
+      name: "Vans",
+    },
+    {
+      id: 3,
+      name: "신발",
+    },
+    {
+      id: 4,
+      name: "컨버스",
+    },
+  ],
+};

--- a/packages/ui/src/ui/raffle-card/RaffleCard.stories.tsx
+++ b/packages/ui/src/ui/raffle-card/RaffleCard.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryFn } from "@storybook/react";
+
+import { RaffleCard } from "./RaffleCard";
+
+const meta: Meta<typeof RaffleCard> = {
+  title: "Components/RaffleCard",
+  component: RaffleCard,
+  argTypes: {
+    name: {
+      control: "text",
+    },
+    price: {
+      control: "text",
+    },
+    hashtags: {
+      control: { type: "object" },
+    },
+    scrapCount: {
+      control: "number",
+    },
+    thumbnailUrl: {
+      control: "text",
+    },
+    endDate: {
+      control: "text",
+    },
+    isBookmarked: {
+      control: "boolean",
+    },
+  },
+  args: {
+    name: "[Vans] 올드스쿨",
+    price: "78,000",
+    hashtags: ["한정판", "Vans"],
+    scrapCount: 3100,
+    thumbnailUrl: "https://shorturl.at/HMedV",
+    isBookmarked: true,
+  },
+};
+
+export default meta;
+
+const Template: StoryFn<typeof RaffleCard> = (args) => <RaffleCard {...args} />;
+
+export const Default = Template.bind({});
+
+export const Closed = Template.bind({});
+Closed.args = { ...Default.args, endDate: "2024-08-02 23:20:59" };

--- a/packages/ui/src/ui/raffle-card/RaffleCard.tsx
+++ b/packages/ui/src/ui/raffle-card/RaffleCard.tsx
@@ -53,7 +53,9 @@ const RaffleCard = ({
       <span className="flex justify-start items-center gap-0.5">
         {isBookmarked && <BookmarkFilledIcon width={15} height={15} />}
         {!isBookmarked && <BookmarkIcon width={15} height={15} />}
-        <p className="font-semibold text-[11px]">{scrapCount}</p>
+        <p className="font-semibold text-[11px]">
+          {scrapCount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",")}
+        </p>
       </span>
     </div>
   );

--- a/packages/ui/src/ui/raffle-card/RaffleCard.tsx
+++ b/packages/ui/src/ui/raffle-card/RaffleCard.tsx
@@ -26,7 +26,7 @@ const RaffleCard = ({
   );
   const isClosed = (endDate && new Date(endDate) < new Date()) || false;
   return (
-    <div className="w-[160px] h-[267px">
+    <div className="w-[160px] h-[267px]">
       <div className="relative flex justify-center items-center w-full h-[160px] mb-2 rounded-sm backdrop-brightness-90">
         <img
           src={thumbnailUrl}

--- a/packages/ui/src/ui/raffle-card/RaffleCard.tsx
+++ b/packages/ui/src/ui/raffle-card/RaffleCard.tsx
@@ -1,0 +1,54 @@
+import { BookmarkIcon, BookmarkFilledIcon } from "@radix-ui/react-icons";
+
+export interface RaffleCardProps {
+  name: string;
+  price: string;
+  hashtags: string[];
+  scrapCount: number;
+  thumbnailUrl: string;
+  endDate?: string;
+  isBookmarked: boolean;
+}
+
+const RaffleCard = ({
+  name,
+  price,
+  hashtags,
+  scrapCount,
+  thumbnailUrl,
+  endDate,
+  isBookmarked,
+}: RaffleCardProps) => {
+  const isClosed = (endDate && new Date(endDate) < new Date()) || false;
+  return (
+    <div className="w-[160px] h-[267px">
+      <div className="relative flex justify-center items-center w-full h-[160px] mb-2 rounded-sm backdrop-brightness-90">
+        <img
+          src={thumbnailUrl}
+          alt={name}
+          className="w-full h-full rounded-sm"
+        />
+        {isClosed && (
+          <div className="absolute w-full h-full flex justify-center items-center bg-black bg-opacity-40 z-10 rounded-sm">
+            <p className="text-white font-bold">마감되었어요 🫠</p>
+          </div>
+        )}
+      </div>
+      <h1 className="font-semibold text-sm">{name}</h1>
+      <p className="font-semibold text-xs text-gray-600 mb-2">{price}원</p>
+      <span className="flex items-center gap-1.5 my-1.5">
+        {hashtags.map((hashtag) => (
+          <p>{hashtag}</p>
+        ))}
+      </span>
+
+      <span className="flex justify-start items-center gap-0.5">
+        {isBookmarked && <BookmarkFilledIcon width={15} height={15} />}
+        {!isBookmarked && <BookmarkIcon width={15} height={15} />}
+        <p className="font-semibold text-[11px]">{scrapCount}</p>
+      </span>
+    </div>
+  );
+};
+
+export { RaffleCard };

--- a/packages/ui/src/ui/raffle-card/RaffleCard.tsx
+++ b/packages/ui/src/ui/raffle-card/RaffleCard.tsx
@@ -25,6 +25,7 @@ const RaffleCard = ({
     14
   );
   const isClosed = (endDate && new Date(endDate) < new Date()) || false;
+
   return (
     <div className="w-[160px] h-[267px]">
       <div className="relative flex justify-center items-center w-full h-[160px] mb-2 rounded-sm backdrop-brightness-90">

--- a/packages/ui/src/ui/raffle-card/RaffleCard.tsx
+++ b/packages/ui/src/ui/raffle-card/RaffleCard.tsx
@@ -1,9 +1,10 @@
 import { BookmarkIcon, BookmarkFilledIcon } from "@radix-ui/react-icons";
+import { Tag, useHiddenTags } from "./use-hiddenTag";
 
 export interface RaffleCardProps {
   name: string;
   price: string;
-  hashtags: string[];
+  hashtags: Tag[];
   scrapCount: number;
   thumbnailUrl: string;
   endDate?: string;
@@ -19,6 +20,10 @@ const RaffleCard = ({
   endDate,
   isBookmarked,
 }: RaffleCardProps) => {
+  const { visibleTags, hiddenTags, tagWrapperRef } = useHiddenTags(
+    hashtags,
+    14
+  );
   const isClosed = (endDate && new Date(endDate) < new Date()) || false;
   return (
     <div className="w-[160px] h-[267px">
@@ -34,14 +39,17 @@ const RaffleCard = ({
           </div>
         )}
       </div>
-      <h1 className="font-semibold text-sm">{name}</h1>
+      <h1 className="font-semibold text-sm truncate">{name}</h1>
       <p className="font-semibold text-xs text-gray-600 mb-2">{price}원</p>
-      <span className="flex items-center gap-1.5 my-1.5">
-        {hashtags.map((hashtag) => (
-          <p>{hashtag}</p>
+      <span
+        ref={tagWrapperRef}
+        className="flex items-center gap-1.5 w-full my-1.5"
+      >
+        {visibleTags.map((hashtag) => (
+          <p key={hashtag.id}>{hashtag.name}</p>
         ))}
+        {hiddenTags.length > 0 && <p>...</p>}
       </span>
-
       <span className="flex justify-start items-center gap-0.5">
         {isBookmarked && <BookmarkFilledIcon width={15} height={15} />}
         {!isBookmarked && <BookmarkIcon width={15} height={15} />}

--- a/packages/ui/src/ui/raffle-card/RaffleCard.tsx
+++ b/packages/ui/src/ui/raffle-card/RaffleCard.tsx
@@ -1,10 +1,12 @@
-import { BookmarkIcon, BookmarkFilledIcon } from "@radix-ui/react-icons";
-import { Tag, useHiddenTags } from "./use-hiddenTag";
+import { Tag as TagType, useHiddenTags } from "./use-hiddenTag";
+import { Tag } from "../tag/Tag";
+import SVGIcon from "@/shared/SVGIcon";
+import { Typography } from "../typography/Typography";
 
 export interface RaffleCardProps {
   name: string;
   price: string;
-  hashtags: Tag[];
+  hashtags: TagType[];
   scrapCount: number;
   thumbnailUrl: string;
   endDate?: string;
@@ -22,7 +24,7 @@ const RaffleCard = ({
 }: RaffleCardProps) => {
   const { visibleTags, hiddenTags, tagWrapperRef } = useHiddenTags(
     hashtags,
-    14
+    20
   );
   const isClosed = (endDate && new Date(endDate) < new Date()) || false;
 
@@ -36,27 +38,37 @@ const RaffleCard = ({
         />
         {isClosed && (
           <div className="absolute w-full h-full flex justify-center items-center bg-black bg-opacity-40 z-10 rounded-sm">
-            <p className="text-white font-bold">마감되었어요 🫠</p>
+            <Typography className="text-white" fontWeight="bold">
+              마감되었어요 🫠
+            </Typography>
           </div>
         )}
       </div>
-      <h1 className="font-semibold text-sm truncate">{name}</h1>
-      <p className="font-semibold text-xs text-gray-600 mb-2">{price}원</p>
+      <Typography className="truncate" fontSize="p2" fontWeight="semibold">
+        {name}
+      </Typography>
+      <Typography
+        className="text-gray-600 mb-2"
+        fontSize="sm2"
+        fontWeight="semibold"
+      >
+        {price}원
+      </Typography>
       <span
         ref={tagWrapperRef}
         className="flex items-center gap-1.5 w-full my-1.5"
       >
         {visibleTags.map((hashtag) => (
-          <p key={hashtag.id}>{hashtag.name}</p>
+          <Tag key={hashtag.id}>{hashtag.name}</Tag>
         ))}
-        {hiddenTags.length > 0 && <p>...</p>}
+        {hiddenTags.length > 0 && <Tag noHash>...</Tag>}
       </span>
       <span className="flex justify-start items-center gap-0.5">
-        {isBookmarked && <BookmarkFilledIcon width={15} height={15} />}
-        {!isBookmarked && <BookmarkIcon width={15} height={15} />}
-        <p className="font-semibold text-[11px]">
+        {isBookmarked && <SVGIcon id="bookmark-fill" />}
+        {!isBookmarked && <SVGIcon id="bookmark" />}
+        <Typography className="text-[11px]" fontWeight="semibold">
           {scrapCount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",")}
-        </p>
+        </Typography>
       </span>
     </div>
   );

--- a/packages/ui/src/ui/raffle-card/use-hiddenTag.tsx
+++ b/packages/ui/src/ui/raffle-card/use-hiddenTag.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useRef, useState } from "react";
+
+export interface Tag {
+  id: number;
+  name: string;
+}
+// 태그와 글자폭을 입력받으면 너비에 맞게 보여질 태그와 보여지지 않을 태그, 태그 컨테이너 ref를 반환합니다.
+export const useHiddenTags = (tags: Tag[], letterSpace: number) => {
+  const [visibleTags, setVisibleTags] = useState<Tag[]>(tags);
+  const [hiddenTags, setHiddenTags] = useState<Tag[]>([]);
+
+  const tagWrapperRef = useRef<HTMLElement>(null);
+  const checkAndManageTags = () => {
+    if (tagWrapperRef.current) {
+      const containerWidth = tagWrapperRef.current.offsetWidth;
+
+      let totalWidth = 0;
+      const newVisibleTags: Tag[] = [];
+      const newHiddenTags: Tag[] = [];
+
+      tags.forEach((tag) => {
+        const tagWidth = tag.name.length * letterSpace;
+        if (totalWidth + tagWidth <= containerWidth) {
+          newVisibleTags.push(tag);
+          totalWidth += tagWidth;
+        } else {
+          newHiddenTags.push(tag);
+        }
+      });
+
+      setVisibleTags(newVisibleTags);
+      setHiddenTags(newHiddenTags);
+    }
+  };
+
+  useEffect(() => {
+    checkAndManageTags();
+  }, [tagWrapperRef.current]);
+
+  return { visibleTags, hiddenTags, tagWrapperRef };
+};

--- a/packages/ui/src/ui/tag/Tag.stories.tsx
+++ b/packages/ui/src/ui/tag/Tag.stories.tsx
@@ -8,6 +8,9 @@ const meta: Meta<typeof Tag> = {
     children: {
       control: { type: "text" },
     },
+    noHash: {
+      control: { type: "boolean" },
+    },
   },
 };
 

--- a/packages/ui/src/ui/tag/Tag.tsx
+++ b/packages/ui/src/ui/tag/Tag.tsx
@@ -1,13 +1,16 @@
-import * as React from "react";
+interface TagProps {
+  children: string;
+  noHash?: boolean;
+}
 
-const Tag = ({ children }: { children: string }) => {
+const Tag = ({ children, noHash = false }: TagProps) => {
   return (
     <div
       className={
         "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors bg-[#F4F4F5] text-[#3F3F46] px-1.5 py-1 gap-2.5"
       }
     >
-      # {children}
+      {!noHash && "#"} {children}
     </div>
   );
 };


### PR DESCRIPTION
## 📖 개요
래플 카드 디자인 컴포넌트 추가 작업

## 💻 작업사항

- RaffleCard 컴포넌트 생성
- RaffleCard Story 생성 
- 제목 길어질 경우 Ellipsis 처리
- 해시 태그가 카드 너비를 초과할 경우 넘는 태그들은 `...`태그로 보여주도록 구현
- MDX Docs 생성

## 🤔 고려사항

- Typo 컴포넌트, SVGIcon 컴포넌트, Hashtag 컴포넌트 필요

## ✔️ check list

- [ ] 작성한 이슈의 내용을 전부 적용했나요?
- [ ] 리뷰어를 등록했나요?
