### PR TITLE
[WRFE-44](feat): 내가 생성한 래플/이벤트 페이지 퍼블리싱

### DIFF
--- a/apps/front/wraffle-webview/app/products/[productId]/page.tsx
+++ b/apps/front/wraffle-webview/app/products/[productId]/page.tsx
@@ -103,11 +103,18 @@ const ProductPage = () => {
         <ProductMainSection
           productData={productData}
           sectionRef={sectionsRef.current['상품']}
+          isCreator={productData.isCreator}
         />
         <Divider />
         <ProductInfoSection
           label='응모 기간'
           data={`${formatDate(productData.startDate)} ~ ${formatDate(productData.endDate)}`}
+          sectionsRef={sectionsRef}
+        />
+        <Divider />
+        <ProductInfoSection
+          label='당첨자 수'
+          data={`${productData.winnerCount}명`}
           sectionsRef={sectionsRef}
         />
         <Divider />
@@ -139,6 +146,7 @@ const ProductPage = () => {
           clipCount={productData.clipCount}
           isApplied={productData.isApplied}
           productImage={productData.images[0]}
+          isCreator={productData.isCreator}
         />
       </div>
     </div>

--- a/apps/front/wraffle-webview/next.config.mjs
+++ b/apps/front/wraffle-webview/next.config.mjs
@@ -30,6 +30,7 @@ const nextConfig = {
         hostname: 'image.vans.co.kr',
       },
     ],
+    domains: ['github.com'],
   },
 };
 

--- a/apps/front/wraffle-webview/src/entities/product/product.ts
+++ b/apps/front/wraffle-webview/src/entities/product/product.ts
@@ -21,6 +21,8 @@ export interface BaseProductData {
   clipCount: number;
   status: string;
   applyCount: number;
+  winnerCount: number;
+  isCreator: boolean;
   isApplied: boolean;
   createUserId: number;
   tags: Tag[];
@@ -44,8 +46,10 @@ export const sampleRaffleData: RaffleData = {
     '제작 박스로 준비해드립니다. 오후 3시 이전 결제 완료 시 택배 출고 드립니다. 당일 상품 출고 마감 시간 3시입니다.',
   etc: '유의사항',
   clipCount: 53,
-  status: 'before',
-  applyCount: 0,
+  status: 'after',
+  applyCount: 10,
+  winnerCount: 2,
+  isCreator: true,
   isApplied: false,
   createUserId: 1,
   tags: [
@@ -70,6 +74,8 @@ export const sampleEventData: EventData = {
   clipCount: 10,
   applyCount: 10,
   status: 'waiting',
+  winnerCount: 2,
+  isCreator: false,
   isApplied: false,
   createUserId: 1,
   tags: [

--- a/apps/front/wraffle-webview/src/features/participate/ui/ParticipateButton.tsx
+++ b/apps/front/wraffle-webview/src/features/participate/ui/ParticipateButton.tsx
@@ -9,6 +9,7 @@ interface ParticipateButtonProps {
   clipCount: number;
   isApplied: boolean;
   productImage: string;
+  isCreator: boolean;
 }
 
 const ParticipateButton = ({
@@ -16,6 +17,7 @@ const ParticipateButton = ({
   clipCount,
   isApplied: initialApplyStatus,
   productImage,
+  isCreator,
 }: ParticipateButtonProps) => {
   const [isBookmarked, setIsBookmarked] = useState(false);
   const [isApplied, setIsApplied] = useState(initialApplyStatus);
@@ -31,24 +33,30 @@ const ParticipateButton = ({
   if (status === 'after') {
     return (
       <div className='p-4'>
-        <Button variant='gray'>응모 마감</Button>
+        <Button variant='gray'>{isCreator ? '추첨 완료' : '응모 마감'}</Button>
       </div>
     );
   }
 
   return (
     <div className='flex gap-4 p-2'>
-      <button onClick={handleBookmark}>
-        <div className='flex flex-col items-center justify-center'>
-          <Icon name='bookmark' color={isBookmarked ? 'black' : ''} />
-          <span>{isBookmarked ? `${clipCount + 1}` : `${clipCount}`}</span>
-        </div>
-      </button>
-      <ParticipateDialog
-        isApplied={isApplied}
-        handleApply={handleApply}
-        productImage={productImage}
-      />
+      {isCreator ? (
+        <Button variant='default'>추첨하러 가기</Button>
+      ) : (
+        <>
+          <button onClick={handleBookmark}>
+            <div className='flex flex-col items-center justify-center'>
+              <Icon name='bookmark' color={isBookmarked ? 'black' : ''} />
+              <span>{isBookmarked ? `${clipCount + 1}` : `${clipCount}`}</span>
+            </div>
+          </button>
+          <ParticipateDialog
+            isApplied={isApplied}
+            handleApply={handleApply}
+            productImage={productImage}
+          />
+        </>
+      )}
     </div>
   );
 };

--- a/apps/front/wraffle-webview/src/widgets/product-info/ui/ProductInfoSection.tsx
+++ b/apps/front/wraffle-webview/src/widgets/product-info/ui/ProductInfoSection.tsx
@@ -1,7 +1,8 @@
+import {useRouter} from 'next/navigation';
 import React, {type MutableRefObject, type RefObject} from 'react';
 import type {RaffleData, EventData} from '@/entities/product/product';
 import ProductImageList from '@/widgets/product-image-list/ProductImageList';
-import {Tag, RaffleCard} from '@wraffle/ui';
+import {Tag, RaffleCard, Icon} from '@wraffle/ui';
 
 type ProductData = RaffleData | EventData;
 
@@ -15,6 +16,8 @@ export const ProductMainSection = ({
   sectionRef: React.RefObject<HTMLDivElement>;
   isCreator: boolean;
 }) => {
+  const router = useRouter();
+
   return (
     <div
       ref={sectionRef}
@@ -23,10 +26,15 @@ export const ProductMainSection = ({
       <ProductImageList images={productData.images} />
       <div className='flex flex-col gap-5 p-4'>
         <div className='flex flex-col gap-2'>
-          <div className='flex flex-row items-start gap-2'>
-            {productData.tags.map(tag => (
-              <Tag key={tag.id}>{tag.name}</Tag>
-            ))}
+          <div className='flex flex-row items-start justify-between gap-2'>
+            <div className='flex flex-row gap-2'>
+              {productData.tags.map(tag => (
+                <Tag key={tag.id}>{tag.name}</Tag>
+              ))}
+            </div>
+            <button onClick={() => router.push('/[id]/edit')}>
+              <Icon name='write' className='ml-auto' width={18} height={18} />
+            </button>
           </div>
           <div className='flex flex-col gap-1'>
             <p className='text-xl font-bold'>{productData.title}</p>

--- a/apps/front/wraffle-webview/src/widgets/product-info/ui/ProductInfoSection.tsx
+++ b/apps/front/wraffle-webview/src/widgets/product-info/ui/ProductInfoSection.tsx
@@ -32,8 +32,16 @@ export const ProductMainSection = ({
                 <Tag key={tag.id}>{tag.name}</Tag>
               ))}
             </div>
-            <button onClick={() => router.push('/[id]/edit')}>
-              <Icon name='write' className='ml-auto' width={18} height={18} />
+            <button
+              onClick={() =>
+                router.push(
+                  `${productData.id}/edit?type=${'raffle' in productData ? 'raffle' : 'event'}`,
+                )
+              }
+            >
+              {isCreator ? (
+                <Icon name='write' className='ml-auto' width={18} height={18} />
+              ) : null}
             </button>
           </div>
           <div className='flex flex-col gap-1'>

--- a/apps/front/wraffle-webview/src/widgets/product-info/ui/ProductInfoSection.tsx
+++ b/apps/front/wraffle-webview/src/widgets/product-info/ui/ProductInfoSection.tsx
@@ -9,9 +9,11 @@ type ProductData = RaffleData | EventData;
 export const ProductMainSection = ({
   productData,
   sectionRef,
+  isCreator,
 }: {
   productData: ProductData;
   sectionRef: React.RefObject<HTMLDivElement>;
+  isCreator: boolean;
 }) => {
   return (
     <div
@@ -29,7 +31,9 @@ export const ProductMainSection = ({
           <div className='flex flex-col gap-1'>
             <p className='text-xl font-bold'>{productData.title}</p>
             <p className='text-xl font-bold'>
-              {productData.price.toLocaleString()}원
+              {isCreator
+                ? `총 ${productData.applyCount}명 응모`
+                : `${productData.price.toLocaleString()}원`}
             </p>
           </div>
         </div>


### PR DESCRIPTION
## 📖 개요

- 내가 생성한 래플/이벤트 페이지 퍼블리싱

## 💻 작업사항

- 내가 생성한 래플/이벤트일 경우
  - 가격 대신 응모 인원 수 표시
  - 응모 버튼 대신 추첨 버튼 표시

- 내가 생성한 경우/아닌 경우 모두 당첨자 수 표시

## 💡 작성한 이슈 외에 작업한 사항

- next.config.mjs 파일에 image 도메인으로 `github.com` 추가 -> api 연동 후 삭제 예정

## ✔️ check list

- [ ] 작성한 이슈의 내용을 전부 적용했나요?
- [ ] 리뷰어를 등록했나요?
