### PR TITLE
[WRFE-74](feat): 회원가입 페이지 API 연동

### DIFF
--- a/apps/front/wraffle-webview/app/join/page.tsx
+++ b/apps/front/wraffle-webview/app/join/page.tsx
@@ -1,19 +1,43 @@
 'use client';
 
 import type {z} from 'zod';
+import {useRouter} from 'next/navigation';
+import {startTransition} from 'react';
 import {Header, ProgressBar, GenericForm} from '@/shared/ui';
+import {signUpUser} from '@/widgets/join/api/server';
 import type {JoinStep} from '@/widgets/join/config';
 import {joinDefaultValues, joinSchema} from '@/widgets/join/config';
 import {Info, Name, Extra, PhoneFunnel} from '@/widgets/join/ui';
 import {zodResolver} from '@hookform/resolvers/zod';
 import {useFunnel} from '@use-funnel/browser';
+import {useToast} from '@wraffle/ui';
 
 const Join = () => {
+  const {toast} = useToast();
+  const router = useRouter();
+
   const onSubmit = (data: z.infer<typeof joinSchema>) => {
-    //!TODO: 회원가입 로직 구현
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const {confirmPassword, ...userJoinData} = data;
-    console.log(userJoinData);
+    startTransition(async () => {
+      try {
+        const {confirmPassword, ...userJoinData} = data;
+        void confirmPassword;
+        await signUpUser(userJoinData);
+        toast({
+          title: '회원가입에 성공했습니다.',
+          duration: 2000,
+          variant: 'success',
+          icon: 'check',
+        });
+        router.push('/login');
+      } catch (error) {
+        toast({
+          title: (error as Error).message,
+          duration: 2000,
+          variant: 'warning',
+          icon: 'close',
+        });
+      }
+    });
   };
 
   const funnel = useFunnel<JoinStep>({

--- a/apps/front/wraffle-webview/app/login/email/page.tsx
+++ b/apps/front/wraffle-webview/app/login/email/page.tsx
@@ -37,7 +37,14 @@ const EmailLogin = () => {
         </Header.Left>
       </Header>
       <div className='flex h-full flex-col items-center px-5'>
-        <Image src='/logo.png' alt='logo' width={136} height={75} priority />
+        <Image
+          src='/logo.png'
+          alt='logo'
+          width={136}
+          height={75}
+          style={{width: 136, height: 75}}
+          priority
+        />
         <section className='mt-7 w-full'>
           <GenericForm
             onSubmit={onSubmit}

--- a/apps/front/wraffle-webview/app/login/page.tsx
+++ b/apps/front/wraffle-webview/app/login/page.tsx
@@ -10,6 +10,7 @@ const Login = () => {
         alt='logo'
         width={136}
         height={75}
+        style={{width: 136, height: 75}}
         className='mt-auto translate-y-1/2 animate-[fade-in-down-half] duration-700'
         priority
       />

--- a/apps/front/wraffle-webview/app/password/reset/page.tsx
+++ b/apps/front/wraffle-webview/app/password/reset/page.tsx
@@ -13,7 +13,7 @@ import {Button, Typography, useToast} from '@wraffle/ui';
 const ResetPasswordPage = () => {
   const router = useRouter();
   const {toast} = useToast();
-  const requestResetPassword = useResetPassword();
+  const {requestResetPassword} = useResetPassword();
 
   const params = useSearchParams();
   const code = params.get('code') || '';

--- a/apps/front/wraffle-webview/app/products/[productId]/page.tsx
+++ b/apps/front/wraffle-webview/app/products/[productId]/page.tsx
@@ -44,21 +44,21 @@ const ProductPage = () => {
 
   const menus = type === 'event' ? [...EVENT_MENUS] : [...RAFFLE_MENUS];
 
-  const data: {
-    raffle: RaffleData;
-    event: EventData;
-  } = {
-    raffle: sampleRaffleData,
-    event: sampleEventData,
-  };
-
   useEffect(() => {
+    const data: {
+      raffle: RaffleData;
+      event: EventData;
+    } = {
+      raffle: sampleRaffleData,
+      event: sampleEventData,
+    };
+
     if (type === 'raffle' || type === 'event') {
       setProductData(data[type]);
     } else {
       router.push('/404');
     }
-  }, [type]);
+  }, [router, type]);
 
   // 메뉴 선택 시 스크롤 이동 함수
   const scrollToSection = (menu: RaffleMenu | EventMenu) => {

--- a/apps/front/wraffle-webview/src/features/password/api/password.ts
+++ b/apps/front/wraffle-webview/src/features/password/api/password.ts
@@ -30,17 +30,7 @@ export const useResetPassword = () => {
     },
   });
 
-  const requestResetPassword = (
-    query: PasswordResetRequest,
-    {
-      onSuccess,
-      onError,
-    }: {onSuccess: () => void; onError: (error: Error) => void},
-  ) => {
-    return mutation.mutate(query, {onSuccess, onError});
-  };
-
-  return requestResetPassword;
+  return {requestResetPassword: mutation.mutate};
 };
 
 /**
@@ -66,15 +56,5 @@ export const useSendEmail = () => {
     },
   });
 
-  const requestSendEmail = (
-    query: string,
-    {
-      onSuccess,
-      onError,
-    }: {onSuccess: () => void; onError: (error: Error) => void},
-  ) => {
-    return mutation.mutate(query, {onSuccess, onError});
-  };
-
-  return requestSendEmail;
+  return {requestSendEmail: mutation.mutate};
 };

--- a/apps/front/wraffle-webview/src/features/share-product-link/ShareDialog.tsx
+++ b/apps/front/wraffle-webview/src/features/share-product-link/ShareDialog.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import {
   Dialog,
   DialogContent,
@@ -23,20 +24,22 @@ const ShareDialog = () => {
               onClick={() => console.log('Instagram Share')}
               className='flex items-center justify-center'
             >
-              <img
+              <Image
                 src='https://i.ibb.co/MDMTKFq/insta.png'
                 alt='Instagram'
-                className='h-[38px] w-[38px]'
+                width={38}
+                height={38}
               />
             </button>
             <button
               onClick={() => console.log('KakaoTalk Share')}
               className='flex items-center justify-center'
             >
-              <img
+              <Image
                 src='https://i.ibb.co/fv4T4x6/kakaotalk.png'
                 alt='Kakao'
-                className='h-[38px] w-[38px]'
+                width={38}
+                height={38}
               />
             </button>
             <button
@@ -45,10 +48,11 @@ const ShareDialog = () => {
               }
               className='flex items-center justify-center'
             >
-              <img
+              <Image
                 src='https://i.ibb.co/PjjqhMq/link.png'
                 alt='Copy Link'
-                className='h-[38px] w-[38px]'
+                width={38}
+                height={38}
               />
             </button>
           </div>

--- a/apps/front/wraffle-webview/src/features/validate-duplication/api/validate.ts
+++ b/apps/front/wraffle-webview/src/features/validate-duplication/api/validate.ts
@@ -1,0 +1,30 @@
+import apiClient from '@/shared/api/apiClient';
+import {useMutation} from '@tanstack/react-query';
+
+type ValidateRequest =
+  | {email: string; nickname?: string}
+  | {email?: string; nickname: string};
+
+export const useValidateDuplication = () => {
+  const mutation = useMutation({
+    mutationFn: async (query: ValidateRequest) => {
+      await apiClient.post<null, ValidateRequest>('/auth/valid-duplicate', {
+        body: query,
+      });
+    },
+  });
+
+  const validateDuplication = (
+    query: ValidateRequest,
+    {
+      onSuccess,
+      onError,
+    }: {onSuccess: () => void; onError: (error: Error) => void},
+  ) => {
+    return mutation.mutate(query, {onSuccess, onError});
+  };
+
+  return {
+    validateDuplication,
+  };
+};

--- a/apps/front/wraffle-webview/src/features/validate-duplication/api/validate.ts
+++ b/apps/front/wraffle-webview/src/features/validate-duplication/api/validate.ts
@@ -14,17 +14,7 @@ export const useValidateDuplication = () => {
     },
   });
 
-  const validateDuplication = (
-    query: ValidateRequest,
-    {
-      onSuccess,
-      onError,
-    }: {onSuccess: () => void; onError: (error: Error) => void},
-  ) => {
-    return mutation.mutate(query, {onSuccess, onError});
-  };
-
   return {
-    validateDuplication,
+    validateDuplication: mutation.mutate,
   };
 };

--- a/apps/front/wraffle-webview/src/features/validate-duplication/ui/ValidateEmailInput.tsx
+++ b/apps/front/wraffle-webview/src/features/validate-duplication/ui/ValidateEmailInput.tsx
@@ -1,42 +1,33 @@
 import {useValidateDuplication} from '../api/validate';
-import {useEffect} from 'react';
+import {useCallback, useEffect} from 'react';
 import {useFormContext} from 'react-hook-form';
+import {emailSchema} from '@/entities/auth';
 import {useDebounce} from '@/shared/hook';
 import {RHFInput} from '@/shared/ui';
 import type {JoinPayload} from '@/widgets/join/config';
 
 const ValidateEmailInput = () => {
-  const {
-    formState: {errors},
-    trigger,
-    watch,
-    setError,
-    clearErrors,
-  } = useFormContext<JoinPayload>();
+  const {watch, setError, clearErrors, trigger} = useFormContext<JoinPayload>();
 
   const email = watch('email');
   const debouncedEmail = useDebounce(email);
 
-  const {validateDuplication: validateEmailDuplication} =
-    useValidateDuplication();
+  const {validateDuplication: validateEmailApi} = useValidateDuplication();
 
-  useEffect(() => {
-    const validateEmailSchema = async () => {
-      const isValid = await trigger('email');
-      if (isValid && email) {
-        setError('email', {
-          type: 'validate',
-          message: '이메일 중복 검사가 진행 중입니다.',
-        });
-      }
-    };
-    if (!email) return;
-    validateEmailSchema();
-  }, [email]);
+  const validateEmailSchema = useCallback(async () => {
+    const isValid = await trigger('email');
+    if (isValid) {
+      setError('email', {
+        type: 'validate',
+        message: '이메일 중복 검사가 진행 중입니다.',
+      });
+    }
+  }, [setError, trigger]);
 
-  useEffect(() => {
-    if (debouncedEmail && errors.email?.type === 'validate') {
-      validateEmailDuplication(
+  const validateEmailDuplication = useCallback(async () => {
+    const isValidSchema = await emailSchema.safeParseAsync(debouncedEmail);
+    if (isValidSchema.success && debouncedEmail) {
+      validateEmailApi(
         {email: debouncedEmail},
         {
           onSuccess: () => {
@@ -48,7 +39,16 @@ const ValidateEmailInput = () => {
         },
       );
     }
-  }, [debouncedEmail]);
+  }, [clearErrors, debouncedEmail, setError, validateEmailApi]);
+
+  useEffect(() => {
+    if (!email) return;
+    validateEmailSchema();
+  }, [email, validateEmailSchema]);
+
+  useEffect(() => {
+    validateEmailDuplication();
+  }, [validateEmailDuplication]);
 
   return (
     <RHFInput

--- a/apps/front/wraffle-webview/src/features/validate-duplication/ui/ValidateEmailInput.tsx
+++ b/apps/front/wraffle-webview/src/features/validate-duplication/ui/ValidateEmailInput.tsx
@@ -1,0 +1,62 @@
+import {useValidateDuplication} from '../api/validate';
+import {useEffect} from 'react';
+import {useFormContext} from 'react-hook-form';
+import {useDebounce} from '@/shared/hook';
+import {RHFInput} from '@/shared/ui';
+import type {JoinPayload} from '@/widgets/join/config';
+
+const ValidateEmailInput = () => {
+  const {
+    formState: {errors},
+    trigger,
+    watch,
+    setError,
+    clearErrors,
+  } = useFormContext<JoinPayload>();
+
+  const email = watch('email');
+  const debouncedEmail = useDebounce(email);
+
+  const {validateDuplication: validateEmailDuplication} =
+    useValidateDuplication();
+
+  useEffect(() => {
+    const validateEmailSchema = async () => {
+      const isValid = await trigger('email');
+      if (isValid && email) {
+        setError('email', {
+          type: 'validate',
+          message: '이메일 중복 검사가 진행 중입니다.',
+        });
+      }
+    };
+    if (!email) return;
+    validateEmailSchema();
+  }, [email]);
+
+  useEffect(() => {
+    if (debouncedEmail && errors.email?.type === 'validate') {
+      validateEmailDuplication(
+        {email: debouncedEmail},
+        {
+          onSuccess: () => {
+            clearErrors('email');
+          },
+          onError: (error: Error) => {
+            setError('email', {message: error.message});
+          },
+        },
+      );
+    }
+  }, [debouncedEmail]);
+
+  return (
+    <RHFInput
+      name='email'
+      label='이메일*'
+      placeholder='이메일을 입력해주세요.'
+    />
+  );
+};
+
+export {ValidateEmailInput};

--- a/apps/front/wraffle-webview/src/features/validate-duplication/ui/ValidateEmailInput.tsx
+++ b/apps/front/wraffle-webview/src/features/validate-duplication/ui/ValidateEmailInput.tsx
@@ -26,7 +26,7 @@ const ValidateEmailInput = () => {
 
   const validateEmailDuplication = useCallback(async () => {
     const isValidSchema = await emailSchema.safeParseAsync(debouncedEmail);
-    if (isValidSchema.success && debouncedEmail) {
+    if (isValidSchema.success) {
       validateEmailApi(
         {email: debouncedEmail},
         {

--- a/apps/front/wraffle-webview/src/features/validate-duplication/ui/ValidateNicknameInput.tsx
+++ b/apps/front/wraffle-webview/src/features/validate-duplication/ui/ValidateNicknameInput.tsx
@@ -26,7 +26,7 @@ const ValidateNicknameInput = () => {
   const validateEmailDuplication = useCallback(async () => {
     const isValidSchema =
       await nicknameSchema.safeParseAsync(debouncedNickname);
-    if (isValidSchema.success && debouncedNickname) {
+    if (isValidSchema.success) {
       validateNicknameApi(
         {nickname: debouncedNickname},
         {

--- a/apps/front/wraffle-webview/src/features/validate-duplication/ui/ValidateNicknameInput.tsx
+++ b/apps/front/wraffle-webview/src/features/validate-duplication/ui/ValidateNicknameInput.tsx
@@ -1,43 +1,33 @@
 import {useValidateDuplication} from '../api/validate';
-import {useEffect} from 'react';
+import {useCallback, useEffect} from 'react';
 import {useFormContext} from 'react-hook-form';
 import {useDebounce} from '@/shared/hook';
 import {RHFInput} from '@/shared/ui';
-import type {JoinPayload} from '@/widgets/join/config';
+import {nicknameSchema, type JoinPayload} from '@/widgets/join/config';
 
 const ValidateNicknameInput = () => {
-  const {
-    formState: {errors},
-    trigger,
-    watch,
-    setError,
-    clearErrors,
-  } = useFormContext<JoinPayload>();
+  const {watch, setError, clearErrors, trigger} = useFormContext<JoinPayload>();
 
   const nickname = watch('nickname');
   const debouncedNickname = useDebounce(nickname);
 
-  const {validateDuplication: validateNicknameDuplication} =
-    useValidateDuplication();
+  const {validateDuplication: validateNicknameApi} = useValidateDuplication();
 
-  useEffect(() => {
-    const validateNicknameSchema = async () => {
-      const isValid = await trigger('nickname');
-      if (isValid && nickname) {
-        setError('nickname', {
-          type: 'validate',
-          message: '닉네임 중복 검사가 진행 중입니다.',
-        });
-      }
-    };
+  const validateNicknameSchema = useCallback(async () => {
+    const isValid = await trigger('nickname');
+    if (isValid) {
+      setError('nickname', {
+        type: 'validate',
+        message: '닉네임 중복 검사가 진행 중입니다.',
+      });
+    }
+  }, [setError, trigger]);
 
-    if (!nickname) return;
-    validateNicknameSchema();
-  }, [nickname]);
-
-  useEffect(() => {
-    if (debouncedNickname && errors.nickname?.type === 'validate') {
-      validateNicknameDuplication(
+  const validateEmailDuplication = useCallback(async () => {
+    const isValidSchema =
+      await nicknameSchema.safeParseAsync(debouncedNickname);
+    if (isValidSchema.success && debouncedNickname) {
+      validateNicknameApi(
         {nickname: debouncedNickname},
         {
           onSuccess: () => {
@@ -49,7 +39,16 @@ const ValidateNicknameInput = () => {
         },
       );
     }
-  }, [debouncedNickname]);
+  }, [clearErrors, debouncedNickname, setError, validateNicknameApi]);
+
+  useEffect(() => {
+    if (!nickname) return;
+    validateNicknameSchema();
+  }, [nickname, validateNicknameSchema]);
+
+  useEffect(() => {
+    validateEmailDuplication();
+  }, [validateEmailDuplication]);
 
   return (
     <RHFInput

--- a/apps/front/wraffle-webview/src/features/validate-duplication/ui/ValidateNicknameInput.tsx
+++ b/apps/front/wraffle-webview/src/features/validate-duplication/ui/ValidateNicknameInput.tsx
@@ -1,0 +1,63 @@
+import {useValidateDuplication} from '../api/validate';
+import {useEffect} from 'react';
+import {useFormContext} from 'react-hook-form';
+import {useDebounce} from '@/shared/hook';
+import {RHFInput} from '@/shared/ui';
+import type {JoinPayload} from '@/widgets/join/config';
+
+const ValidateNicknameInput = () => {
+  const {
+    formState: {errors},
+    trigger,
+    watch,
+    setError,
+    clearErrors,
+  } = useFormContext<JoinPayload>();
+
+  const nickname = watch('nickname');
+  const debouncedNickname = useDebounce(nickname);
+
+  const {validateDuplication: validateNicknameDuplication} =
+    useValidateDuplication();
+
+  useEffect(() => {
+    const validateNicknameSchema = async () => {
+      const isValid = await trigger('nickname');
+      if (isValid && nickname) {
+        setError('nickname', {
+          type: 'validate',
+          message: '닉네임 중복 검사가 진행 중입니다.',
+        });
+      }
+    };
+
+    if (!nickname) return;
+    validateNicknameSchema();
+  }, [nickname]);
+
+  useEffect(() => {
+    if (debouncedNickname && errors.nickname?.type === 'validate') {
+      validateNicknameDuplication(
+        {nickname: debouncedNickname},
+        {
+          onSuccess: () => {
+            clearErrors('nickname');
+          },
+          onError: (error: Error) => {
+            setError('nickname', {message: error.message});
+          },
+        },
+      );
+    }
+  }, [debouncedNickname]);
+
+  return (
+    <RHFInput
+      name='nickname'
+      label='닉네임*'
+      placeholder='닉네임을 입력해주세요.'
+    />
+  );
+};
+
+export {ValidateNicknameInput};

--- a/apps/front/wraffle-webview/src/features/validate-duplication/ui/index.ts
+++ b/apps/front/wraffle-webview/src/features/validate-duplication/ui/index.ts
@@ -1,0 +1,2 @@
+export * from './ValidateEmailInput';
+export * from './ValidateNicknameInput';

--- a/apps/front/wraffle-webview/src/features/validate-phone/api/request.ts
+++ b/apps/front/wraffle-webview/src/features/validate-phone/api/request.ts
@@ -11,15 +11,5 @@ export const useRequestCode = () => {
     },
   });
 
-  const requestCode = (
-    query: RequestCodeRequest,
-    {
-      onSuccess,
-      onError,
-    }: {onSuccess: () => void; onError: (error: Error) => void},
-  ) => {
-    return mutation.mutate(query, {onSuccess, onError});
-  };
-
-  return {requestCode};
+  return {requestCode: mutation.mutate};
 };

--- a/apps/front/wraffle-webview/src/features/validate-phone/api/request.ts
+++ b/apps/front/wraffle-webview/src/features/validate-phone/api/request.ts
@@ -1,0 +1,28 @@
+import apiClient from '@/shared/api/apiClient';
+import {useMutation} from '@tanstack/react-query';
+
+interface RequestCodeRequest {
+  phoneNumber: string;
+}
+
+export const useRequestCode = () => {
+  const mutation = useMutation({
+    mutationFn: async (query: RequestCodeRequest) => {
+      await apiClient.post<null, RequestCodeRequest>('/phone-auth/request', {
+        body: query,
+      });
+    },
+  });
+
+  const requestCode = (
+    query: RequestCodeRequest,
+    {
+      onSuccess,
+      onError,
+    }: {onSuccess: () => void; onError: (error: Error) => void},
+  ) => {
+    return mutation.mutate(query, {onSuccess, onError});
+  };
+
+  return requestCode;
+};

--- a/apps/front/wraffle-webview/src/features/validate-phone/api/request.ts
+++ b/apps/front/wraffle-webview/src/features/validate-phone/api/request.ts
@@ -21,5 +21,5 @@ export const useRequestCode = () => {
     return mutation.mutate(query, {onSuccess, onError});
   };
 
-  return requestCode;
+  return {requestCode};
 };

--- a/apps/front/wraffle-webview/src/features/validate-phone/api/verify.ts
+++ b/apps/front/wraffle-webview/src/features/validate-phone/api/verify.ts
@@ -1,18 +1,22 @@
-import type {RequestCodeRequest} from '../config/type';
 import apiClient from '@/shared/api/apiClient';
 import {useMutation} from '@tanstack/react-query';
 
-export const useRequestCode = () => {
+interface VerifyCodeRequest {
+  phoneNumber: string;
+  code: string;
+}
+
+export const useVerifyCode = () => {
   const mutation = useMutation({
-    mutationFn: async (query: RequestCodeRequest) => {
-      await apiClient.post<null, RequestCodeRequest>('/phone-auth/request', {
+    mutationFn: async (query: VerifyCodeRequest) => {
+      await apiClient.post<null, VerifyCodeRequest>('/phone-auth/verify', {
         body: query,
       });
     },
   });
 
-  const requestCode = (
-    query: RequestCodeRequest,
+  const verifyCode = (
+    query: VerifyCodeRequest,
     {
       onSuccess,
       onError,
@@ -21,5 +25,5 @@ export const useRequestCode = () => {
     return mutation.mutate(query, {onSuccess, onError});
   };
 
-  return requestCode;
+  return verifyCode;
 };

--- a/apps/front/wraffle-webview/src/features/validate-phone/api/verify.ts
+++ b/apps/front/wraffle-webview/src/features/validate-phone/api/verify.ts
@@ -25,5 +25,5 @@ export const useVerifyCode = () => {
     return mutation.mutate(query, {onSuccess, onError});
   };
 
-  return verifyCode;
+  return {verifyCode};
 };

--- a/apps/front/wraffle-webview/src/features/validate-phone/api/verify.ts
+++ b/apps/front/wraffle-webview/src/features/validate-phone/api/verify.ts
@@ -15,15 +15,5 @@ export const useVerifyCode = () => {
     },
   });
 
-  const verifyCode = (
-    query: VerifyCodeRequest,
-    {
-      onSuccess,
-      onError,
-    }: {onSuccess: () => void; onError: (error: Error) => void},
-  ) => {
-    return mutation.mutate(query, {onSuccess, onError});
-  };
-
-  return {verifyCode};
+  return {verifyCode: mutation.mutate};
 };

--- a/apps/front/wraffle-webview/src/features/validate-phone/config/const.ts
+++ b/apps/front/wraffle-webview/src/features/validate-phone/config/const.ts
@@ -1,3 +1,2 @@
 export const DEFAULT_ERROR_MESSAGE = '';
-export const MISMATCHED_CODE_ERROR_MESSAGE = '인증번호가 일치하지 않습니다.';
-export const VERIFY_CODE_LENGTH = 4;
+export const VERIFY_CODE_LENGTH = 6;

--- a/apps/front/wraffle-webview/src/features/validate-phone/config/type.ts
+++ b/apps/front/wraffle-webview/src/features/validate-phone/config/type.ts
@@ -1,0 +1,8 @@
+export interface RequestCodeRequest {
+  phoneNumber: string;
+}
+
+export interface VerifyCodeRequest {
+  phoneNumber: string;
+  code: string;
+}

--- a/apps/front/wraffle-webview/src/features/validate-phone/ui/RequestCode.tsx
+++ b/apps/front/wraffle-webview/src/features/validate-phone/ui/RequestCode.tsx
@@ -1,4 +1,5 @@
 import {useRequestCode} from '../api/request';
+import type {RequestCodeRequest} from '../config/type';
 import type {Dispatch, SetStateAction} from 'react';
 import {useEffect, useState} from 'react';
 import type {FieldError} from 'react-hook-form';
@@ -29,7 +30,7 @@ const RequestCode = ({
 
   const requestCode = useRequestCode();
 
-  const handleRequestCode = (phoneNumber: string) => {
+  const handleRequestCode = ({phoneNumber}: RequestCodeRequest) => {
     requestCode(
       {phoneNumber},
       {
@@ -56,7 +57,7 @@ const RequestCode = ({
     if (isValid) {
       const phoneNumber = first.concat(middle, last);
       onChangePhoneNumber(phoneNumber);
-      handleRequestCode(phoneNumber);
+      handleRequestCode({phoneNumber});
     }
   }, [first, middle, last]);
 

--- a/apps/front/wraffle-webview/src/features/validate-phone/ui/RequestCode.tsx
+++ b/apps/front/wraffle-webview/src/features/validate-phone/ui/RequestCode.tsx
@@ -1,3 +1,4 @@
+import {useRequestCode} from '../api/request';
 import type {Dispatch, SetStateAction} from 'react';
 import {useEffect, useState} from 'react';
 import type {FieldError} from 'react-hook-form';
@@ -26,6 +27,23 @@ const RequestCode = ({
   const [last, handleLast] = useInput('');
   const [errorMessage, setErrorMessage] = useState('');
 
+  const requestCode = useRequestCode();
+
+  const handleRequestCode = (phoneNumber: string) => {
+    requestCode(
+      {phoneNumber},
+      {
+        onSuccess: () => {
+          onChangeIsVerified(true);
+        },
+        onError: (error: Error) => {
+          setErrorMessage(error.message);
+          onChangeIsVerified(false);
+        },
+      },
+    );
+  };
+
   const isValid =
     first &&
     (middle.length === MAX_INPUT_LENGTH ||
@@ -38,12 +56,7 @@ const RequestCode = ({
     if (isValid) {
       const phoneNumber = first.concat(middle, last);
       onChangePhoneNumber(phoneNumber);
-      // !TODO: request API
-      // 성공 시 onChangeIsVerified(true)
-      onChangeIsVerified(true);
-      // 실패 시 setErrorMessage에 에러메세지
-      // setErrorMessage('이미 가입된 번호입니다.');
-      // onChangeIsVerified(false);
+      handleRequestCode(phoneNumber);
     }
   }, [first, middle, last]);
 

--- a/apps/front/wraffle-webview/src/features/validate-phone/ui/RequestCode.tsx
+++ b/apps/front/wraffle-webview/src/features/validate-phone/ui/RequestCode.tsx
@@ -28,7 +28,7 @@ const RequestCode = ({
   const [last, handleLast] = useInput('');
   const [errorMessage, setErrorMessage] = useState('');
 
-  const requestCode = useRequestCode();
+  const {requestCode} = useRequestCode();
 
   const handleRequestCode = ({phoneNumber}: RequestCodeRequest) => {
     requestCode(

--- a/apps/front/wraffle-webview/src/features/validate-phone/ui/RequestCode.tsx
+++ b/apps/front/wraffle-webview/src/features/validate-phone/ui/RequestCode.tsx
@@ -1,7 +1,7 @@
 import {useRequestCode} from '../api/request';
 import type {RequestCodeRequest} from '../config/type';
 import type {Dispatch, SetStateAction} from 'react';
-import {useEffect, useState} from 'react';
+import {useCallback, useEffect, useState} from 'react';
 import type {FieldError} from 'react-hook-form';
 import {useAutoFocus, useInput} from '@/shared/hook';
 import {handleMaxLength} from '@/shared/util';
@@ -30,20 +30,23 @@ const RequestCode = ({
 
   const {requestCode} = useRequestCode();
 
-  const handleRequestCode = ({phoneNumber}: RequestCodeRequest) => {
-    requestCode(
-      {phoneNumber},
-      {
-        onSuccess: () => {
-          onChangeIsVerified(true);
+  const handleRequestCode = useCallback(
+    ({phoneNumber}: RequestCodeRequest) => {
+      requestCode(
+        {phoneNumber},
+        {
+          onSuccess: () => {
+            onChangeIsVerified(true);
+          },
+          onError: (error: Error) => {
+            setErrorMessage(error.message);
+            onChangeIsVerified(false);
+          },
         },
-        onError: (error: Error) => {
-          setErrorMessage(error.message);
-          onChangeIsVerified(false);
-        },
-      },
-    );
-  };
+      );
+    },
+    [onChangeIsVerified, requestCode],
+  );
 
   const isValid =
     first &&
@@ -59,7 +62,15 @@ const RequestCode = ({
       onChangePhoneNumber(phoneNumber);
       handleRequestCode({phoneNumber});
     }
-  }, [first, middle, last]);
+  }, [
+    first,
+    handleRequestCode,
+    isValid,
+    last,
+    middle,
+    onChangeIsVerified,
+    onChangePhoneNumber,
+  ]);
 
   return (
     <InputField>

--- a/apps/front/wraffle-webview/src/features/validate-phone/ui/VerifyCode.tsx
+++ b/apps/front/wraffle-webview/src/features/validate-phone/ui/VerifyCode.tsx
@@ -3,6 +3,7 @@ import {DEFAULT_ERROR_MESSAGE, VERIFY_CODE_LENGTH} from '../config/const';
 import type {VerifyCodeRequest} from '../config/type';
 import {useEffect, useState} from 'react';
 import {useInput} from '@/shared/hook';
+import {handleMaxLength} from '@/shared/util';
 import {InputField} from '@wraffle/ui';
 
 interface VerifyCodeProps {
@@ -39,7 +40,13 @@ const VerifyCode = ({phoneNumber, onSuccess}: VerifyCodeProps) => {
 
   return (
     <InputField>
-      <InputField.Input type='number' value={code} onChange={handleCode} />
+      <InputField.Input
+        type='number'
+        maxLength={VERIFY_CODE_LENGTH}
+        value={code}
+        onChange={handleCode}
+        onInput={handleMaxLength}
+      />
       <InputField.ErrorMessage isError>{errorMessage}</InputField.ErrorMessage>
     </InputField>
   );

--- a/apps/front/wraffle-webview/src/features/validate-phone/ui/VerifyCode.tsx
+++ b/apps/front/wraffle-webview/src/features/validate-phone/ui/VerifyCode.tsx
@@ -1,7 +1,7 @@
 import {useVerifyCode} from '../api/verify';
 import {DEFAULT_ERROR_MESSAGE, VERIFY_CODE_LENGTH} from '../config/const';
 import type {VerifyCodeRequest} from '../config/type';
-import {useEffect, useState} from 'react';
+import {useCallback, useEffect, useState} from 'react';
 import {useInput} from '@/shared/hook';
 import {handleMaxLength} from '@/shared/util';
 import {InputField} from '@wraffle/ui';
@@ -17,26 +17,29 @@ const VerifyCode = ({phoneNumber, onSuccess}: VerifyCodeProps) => {
 
   const {verifyCode} = useVerifyCode();
 
-  const handleVerifyCode = ({phoneNumber, code}: VerifyCodeRequest) => {
-    verifyCode(
-      {phoneNumber, code},
-      {
-        onSuccess: () => {
-          onSuccess();
+  const handleVerifyCode = useCallback(
+    ({phoneNumber, code}: VerifyCodeRequest) => {
+      verifyCode(
+        {phoneNumber, code},
+        {
+          onSuccess: () => {
+            onSuccess();
+          },
+          onError: (error: Error) => {
+            setErrorMessage(error.message);
+          },
         },
-        onError: (error: Error) => {
-          setErrorMessage(error.message);
-        },
-      },
-    );
-  };
+      );
+    },
+    [onSuccess, verifyCode],
+  );
 
   useEffect(() => {
     setErrorMessage(DEFAULT_ERROR_MESSAGE);
     if (code.length === VERIFY_CODE_LENGTH) {
       handleVerifyCode({phoneNumber, code});
     }
-  }, [code]);
+  }, [code, handleVerifyCode, phoneNumber]);
 
   return (
     <InputField>

--- a/apps/front/wraffle-webview/src/features/validate-phone/ui/VerifyCode.tsx
+++ b/apps/front/wraffle-webview/src/features/validate-phone/ui/VerifyCode.tsx
@@ -15,7 +15,7 @@ const VerifyCode = ({phoneNumber, onSuccess}: VerifyCodeProps) => {
   const [code, handleCode] = useInput('');
   const [errorMessage, setErrorMessage] = useState(DEFAULT_ERROR_MESSAGE);
 
-  const verifyCode = useVerifyCode();
+  const {verifyCode} = useVerifyCode();
 
   const handleVerifyCode = ({phoneNumber, code}: VerifyCodeRequest) => {
     verifyCode(

--- a/apps/front/wraffle-webview/src/features/validate-phone/ui/VerifyCode.tsx
+++ b/apps/front/wraffle-webview/src/features/validate-phone/ui/VerifyCode.tsx
@@ -1,29 +1,45 @@
+import {useVerifyCode} from '../api/verify';
 import {DEFAULT_ERROR_MESSAGE, VERIFY_CODE_LENGTH} from '../config/const';
+import type {VerifyCodeRequest} from '../config/type';
 import {useEffect, useState} from 'react';
 import {useInput} from '@/shared/hook';
 import {InputField} from '@wraffle/ui';
 
 interface VerifyCodeProps {
+  phoneNumber: string;
   onSuccess: () => void;
 }
 
-const VerifyCode = ({onSuccess}: VerifyCodeProps) => {
+const VerifyCode = ({phoneNumber, onSuccess}: VerifyCodeProps) => {
   const [code, handleCode] = useInput('');
   const [errorMessage, setErrorMessage] = useState(DEFAULT_ERROR_MESSAGE);
+
+  const verifyCode = useVerifyCode();
+
+  const handleVerifyCode = ({phoneNumber, code}: VerifyCodeRequest) => {
+    verifyCode(
+      {phoneNumber, code},
+      {
+        onSuccess: () => {
+          onSuccess();
+        },
+        onError: (error: Error) => {
+          setErrorMessage(error.message);
+        },
+      },
+    );
+  };
 
   useEffect(() => {
     setErrorMessage(DEFAULT_ERROR_MESSAGE);
     if (code.length === VERIFY_CODE_LENGTH) {
-      // !TODO: reuqest API
-      // 성공 시 onSuccess();
-      onSuccess();
-      // 실패 시 setErrorMessage(MISMATCHED_CODE_ERROR_MESSAGE);
+      handleVerifyCode({phoneNumber, code});
     }
   }, [code]);
 
   return (
     <InputField>
-      <InputField.Input value={code} onChange={handleCode} />
+      <InputField.Input type='number' value={code} onChange={handleCode} />
       <InputField.ErrorMessage isError>{errorMessage}</InputField.ErrorMessage>
     </InputField>
   );

--- a/apps/front/wraffle-webview/src/shared/api/fetchClient.ts
+++ b/apps/front/wraffle-webview/src/shared/api/fetchClient.ts
@@ -15,10 +15,24 @@ export class FetchClient {
     this.baseUrl = baseUrl;
   }
 
+  /*
+  request 메소드 오버로드 정의
+  TResponse를 지정하는 경우 리턴 타입은 Promise<ApiResponseWithData<TResponse>>
+  TResponse를 지정하지 않는 경우 리턴 타입은 Promise<ApiResponseWithData<undefined> | null>
+  */
   private async request<TResponse, TBody = unknown>(
     url: string,
     options: FetchOptions<TBody>,
-  ): Promise<ApiResponseWithData<TResponse>> {
+  ): Promise<ApiResponseWithData<TResponse>>;
+  private async request<TBody = unknown>(
+    url: string,
+    options: FetchOptions<TBody>,
+  ): Promise<ApiResponseWithData<undefined> | null>;
+
+  private async request<TResponse = undefined, TBody = unknown>(
+    url: string,
+    options: FetchOptions<TBody>,
+  ): Promise<ApiResponseWithData<TResponse> | null> {
     const {
       withAuth = false,
       contentType = 'application/json',
@@ -48,6 +62,10 @@ export class FetchClient {
       headers: allHeaders,
       body: body ? JSON.stringify(body) : undefined,
     });
+
+    if (response.status === 204) {
+      return null;
+    }
 
     const responseData = await response.json();
 

--- a/apps/front/wraffle-webview/src/shared/hook/index.ts
+++ b/apps/front/wraffle-webview/src/shared/hook/index.ts
@@ -1,2 +1,3 @@
 export * from './useAutoFocus';
+export * from './useDebounce';
 export * from './useInput';

--- a/apps/front/wraffle-webview/src/shared/hook/useDebounce.ts
+++ b/apps/front/wraffle-webview/src/shared/hook/useDebounce.ts
@@ -1,0 +1,19 @@
+import {useEffect, useState} from 'react';
+
+const useDebounce = <T>(value: T, delay = 300) => {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timerId = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(timerId);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+};
+
+export {useDebounce};

--- a/apps/front/wraffle-webview/src/widgets/history-list/ui/ProductList.tsx
+++ b/apps/front/wraffle-webview/src/widgets/history-list/ui/ProductList.tsx
@@ -15,7 +15,6 @@ interface ProductListProps<T extends {id: number}> {
 
 export const ProductList = <T extends {id: number}>({
   products,
-  block,
   emptyInfo,
 }: ProductListProps<T>) => (
   <>

--- a/apps/front/wraffle-webview/src/widgets/join/api/server.ts
+++ b/apps/front/wraffle-webview/src/widgets/join/api/server.ts
@@ -1,0 +1,11 @@
+'use server';
+
+import type {JoinRequest} from '../config/type';
+import apiClient from '@/shared/api/apiClient';
+import type {Tokens} from '@/shared/api/type';
+
+export const signUpUser = async (data: JoinRequest) => {
+  await apiClient.post<Tokens, JoinRequest>('/auth/signup', {
+    body: data,
+  });
+};

--- a/apps/front/wraffle-webview/src/widgets/join/config/schema.ts
+++ b/apps/front/wraffle-webview/src/widgets/join/config/schema.ts
@@ -6,7 +6,7 @@ import {
 } from '@/entities/auth/schema';
 import {getDefaults} from '@/shared/util';
 
-const confirmPasswordSchema = z
+export const confirmPasswordSchema = z
   .string()
   .regex(
     passwordRegex,
@@ -14,40 +14,40 @@ const confirmPasswordSchema = z
   )
   .default('');
 
-const nameSchema = z
+export const nameSchema = z
   .string()
   .min(1, {message: '이름을 입력해 주세요.'})
   .default('');
 
-const nicknameSchema = z
+export const nicknameSchema = z
   .string()
   .min(1, {message: '닉네임을 입력해 주세요.'})
   .default('');
 
-const phoneNumberSchema = z
+export const phoneNumberSchema = z
   .string()
   .min(1, {message: '전화번호를 입력해 주세요.'})
   .default('');
 
-const isAgreedSchema = z
+export const isAgreedSchema = z
   .boolean()
   .default(false)
   .refine(val => val === true, {
     message: '필수 선택입니다.',
   });
-const isPrivacyAgreedSchema = z
+export const isPrivacyAgreedSchema = z
   .boolean()
   .default(false)
   .refine(val => val === true, {
     message: '필수 선택입니다.',
   });
-const isThirdAgreedSchema = z
+export const isThirdAgreedSchema = z
   .boolean()
   .default(false)
   .refine(val => val === true, {
     message: '필수 선택입니다.',
   });
-const isMarketingAgreedSchema = z.boolean().optional().default(false);
+export const isMarketingAgreedSchema = z.boolean().optional().default(false);
 
 export const joinSchema = z
   .object({

--- a/apps/front/wraffle-webview/src/widgets/join/config/type.ts
+++ b/apps/front/wraffle-webview/src/widgets/join/config/type.ts
@@ -1,0 +1,11 @@
+export interface JoinRequest {
+  name: string;
+  email: string;
+  password: string;
+  nickname: string;
+  phoneNumber: string;
+  isAgreed: boolean;
+  isPrivacyAgreed: boolean;
+  isThirdAgreed: boolean;
+  isMarketingAgreed: boolean;
+}

--- a/apps/front/wraffle-webview/src/widgets/join/ui/Extra.tsx
+++ b/apps/front/wraffle-webview/src/widgets/join/ui/Extra.tsx
@@ -5,8 +5,7 @@ import {FormControl, FormField, FormItem} from '@/shared/ui';
 import {Button, ErrorMessage, Icon, Typography, CheckBox} from '@wraffle/ui';
 
 const Extra = () => {
-  const {control, setValue, watch, trigger, clearErrors} =
-    useFormContext<JoinPayload>();
+  const {control, setValue, watch, clearErrors} = useFormContext<JoinPayload>();
   const watchAllFields = watch();
 
   const allChecked = terms.every(term => watchAllFields[term.id]);
@@ -19,10 +18,8 @@ const Extra = () => {
 
   const handleAllCheckChange = (isChecked: boolean) => {
     terms.forEach(term => {
-      setValue(term.id, isChecked);
-      if (!isChecked) {
-        trigger();
-      } else {
+      setValue(term.id, isChecked, {shouldValidate: true});
+      if (isChecked) {
         clearErrors(term.id);
       }
     });

--- a/apps/front/wraffle-webview/src/widgets/join/ui/Info.tsx
+++ b/apps/front/wraffle-webview/src/widgets/join/ui/Info.tsx
@@ -1,6 +1,7 @@
 import type {JoinPayload} from '../config';
 import {useEffect} from 'react';
 import {useFormContext} from 'react-hook-form';
+import {ValidateEmailInput} from '@/features/validate-duplication/ui';
 import {RHFInput} from '@/shared/ui';
 import {Button, Typography} from '@wraffle/ui';
 
@@ -47,11 +48,7 @@ const Info = ({onNext}: InfoProps) => {
         </Typography>
       </div>
 
-      <RHFInput
-        name='email'
-        label='이메일*'
-        placeholder='이메일을 입력해주세요.'
-      />
+      <ValidateEmailInput />
       <RHFInput
         type='password'
         name='password'

--- a/apps/front/wraffle-webview/src/widgets/join/ui/Info.tsx
+++ b/apps/front/wraffle-webview/src/widgets/join/ui/Info.tsx
@@ -35,7 +35,7 @@ const Info = ({onNext}: InfoProps) => {
     if (touchedFields.password) {
       trigger('confirmPassword');
     }
-  }, [password]);
+  }, [password, touchedFields.password, trigger]);
 
   return (
     <div>

--- a/apps/front/wraffle-webview/src/widgets/join/ui/Name.tsx
+++ b/apps/front/wraffle-webview/src/widgets/join/ui/Name.tsx
@@ -1,5 +1,6 @@
 import type {JoinPayload} from '../config';
 import {useFormContext} from 'react-hook-form';
+import {ValidateNicknameInput} from '@/features/validate-duplication/ui';
 import {RHFInput} from '@/shared/ui';
 import {Button, Typography} from '@wraffle/ui';
 
@@ -32,11 +33,7 @@ const Name = ({onNext}: NameProps) => {
       </div>
 
       <RHFInput name='name' label='이름*' placeholder='이름을 입력해주세요.' />
-      <RHFInput
-        name='nickname'
-        label='닉네임*'
-        placeholder='닉네임을 입력해주세요.'
-      />
+      <ValidateNicknameInput />
 
       <div className='fixed inset-x-0 bottom-0 bg-white p-5'>
         <Button

--- a/apps/front/wraffle-webview/src/widgets/join/ui/Phone/Code.tsx
+++ b/apps/front/wraffle-webview/src/widgets/join/ui/Phone/Code.tsx
@@ -26,7 +26,10 @@ const Code = ({onNext}: CodeProps) => {
         </Typography>
       </div>
 
-      <VerifyCode onSuccess={handleVerify} />
+      <VerifyCode
+        phoneNumber={getValues('phoneNumber')}
+        onSuccess={handleVerify}
+      />
       <div className='flex justify-end pr-2 pt-1'>
         <Timer timerSecond={180} />
       </div>

--- a/apps/front/wraffle-webview/src/widgets/join/ui/Phone/PhoneNumber.tsx
+++ b/apps/front/wraffle-webview/src/widgets/join/ui/Phone/PhoneNumber.tsx
@@ -1,5 +1,5 @@
 import type {JoinPayload} from '../../config';
-import {useState} from 'react';
+import {useCallback, useState} from 'react';
 import {useFormContext} from 'react-hook-form';
 import {RequestCode} from '@/features/validate-phone/ui/RequestCode';
 import {Button, Typography} from '@wraffle/ui';
@@ -17,9 +17,12 @@ const PhoneNumber = ({onNext}: PhoneNumberProps) => {
 
   const [isVerified, handleIsVerified] = useState(false);
 
-  const handlePhoneNumber = (phone: string) => {
-    setValue('phoneNumber', phone, {shouldValidate: true});
-  };
+  const handlePhoneNumber = useCallback(
+    (phone: string) => {
+      setValue('phoneNumber', phone, {shouldValidate: true});
+    },
+    [setValue],
+  );
 
   return (
     <div>

--- a/apps/front/wraffle-webview/src/widgets/product-list/create/ui/DateStepList.tsx
+++ b/apps/front/wraffle-webview/src/widgets/product-list/create/ui/DateStepList.tsx
@@ -5,7 +5,7 @@ import {useFormContext, useWatch} from 'react-hook-form';
 import type {CreateEventPayload} from '@/entities/product/model';
 import {WinnerCountForm} from '@/features/product-form/ui';
 import {getTypeText} from '@/shared/util';
-import {Button, Typography, useToast} from '@wraffle/ui';
+import {Button, Typography} from '@wraffle/ui';
 
 export const DateStep = ({
   type,

--- a/packages/shared/eslint-config/next.js
+++ b/packages/shared/eslint-config/next.js
@@ -7,6 +7,7 @@ module.exports = {
   extends: [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
+    "plugin:react-hooks/recommended",
     "prettier",
     require.resolve("@vercel/style-guide/eslint/next"),
     "turbo",

--- a/packages/shared/eslint-config/package.json
+++ b/packages/shared/eslint-config/package.json
@@ -8,12 +8,13 @@
     "react-internal.js"
   ],
   "devDependencies": {
-    "@vercel/style-guide": "^5.2.0",
-    "eslint-config-turbo": "^2.0.0",
-    "eslint-config-prettier": "^9.1.0",
-    "eslint-plugin-only-warn": "^1.1.0",
-    "@typescript-eslint/parser": "^7.1.0",
     "@typescript-eslint/eslint-plugin": "^7.1.0",
+    "@typescript-eslint/parser": "^7.1.0",
+    "@vercel/style-guide": "^5.2.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-config-turbo": "^2.0.0",
+    "eslint-plugin-only-warn": "^1.1.0",
+    "eslint-plugin-react-hooks": "^5.1.0",
     "typescript": "^5.3.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,6 +314,9 @@ importers:
       eslint-plugin-only-warn:
         specifier: ^1.1.0
         version: 1.1.0
+      eslint-plugin-react-hooks:
+        specifier: ^5.1.0
+        version: 5.1.0(eslint@8.57.1)
       typescript:
         specifier: ^5.3.3
         version: 5.6.3
@@ -5048,6 +5051,12 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
+
+  eslint-plugin-react-hooks@5.1.0:
+    resolution: {integrity: sha512-mpJRtPgHN2tNAvZ35AMfqeB3Xqeo273QxrHJsbBEPWODRM4r0yB6jfoROqKEYrOn27UtRPpcpHc2UqyBSuUNTw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
 
   eslint-plugin-react@7.37.2:
     resolution: {integrity: sha512-EsTAnj9fLVr/GZleBLFbj/sSuXeWmp1eXIN60ceYnZveqEaUCyW4X+Vh4WTdUhCkW4xutXYqTXCUSyqD4rB75w==}
@@ -14816,6 +14825,10 @@ snapshots:
       eslint: 8.57.1
 
   eslint-plugin-react-hooks@5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1):
+    dependencies:
+      eslint: 8.57.1
+
+  eslint-plugin-react-hooks@5.1.0(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
 


### PR DESCRIPTION
## 📖 개요
회원가입에 필요한 API를 연동합니다.
- 휴대폰 인증코드 발송 API
- 휴대폰 인증코드 검증 API
- 이메일, 닉네임 중복검사 API
- 회원가입 API

[미디움 기술 블로그](https://medium.com/wraffle-tech/next-js%EC%97%90%EC%84%9C-zod-react-hook-form-use-funnel%EC%9D%84-%EC%82%AC%EC%9A%A9%ED%95%98%EC%97%AC-%ED%9A%8C%EC%9B%90%EA%B0%80%EC%9E%85-%EC%8A%A4%ED%85%9D-%EA%B5%AC%ED%98%84%ED%95%98%EA%B8%B0-7daa87bfa108)에 Funnel Step과 API 연동 과정을 기록했습니다.


## 💻 작업사항

- 휴대폰 인증코드 발송/검증 API를 useMutation API를 통해 연동했습니다.
- 이메일, 닉네임 중복검사 API는 실시간으로 API를 호출하기 때문에 `debounce`를 적용했습니다.
  - `useDebounce` 커스텀훅을 만들었으니 필요한 곳이 있다면 이 훅을 사용하시길 바랍니다.
  - 중복검사 API가 동작하는 동안 유효성 검사가 통과되지 않도록 처리했습니다.
- 회원가입 API는 민감한 데이터 보호와 검증 우회 방지를 위해 `서버액션`으로 연동했습니다.
 
## 💡 작성한 이슈 외에 작업한 사항

### FetchClient에서 `no-content`에 대한 처리를 추가했습니다.
- 래플 서버에서 API 응답으로 response가 없는 API가 있습니다. (201 status에서 응답이 no-content)
- 현재 서버팀에서 응답이 없는 API(no-content)를 수정하는 작업을 진행중입니다. 
- 별도로 status 204 응답에 대한 처리를 Fetch Client에 업데이트 했습니다.

### ⚠️ Lint 규칙을 추가함에 따라 기존 코드를 리팩토링 했습니다.
react-hooks ESLint 규칙을 추가하여 기존 코드에서 발생하는 Lint warning을 수정 및 리팩토링 했습니다.
본인이 작성한 코드의 변경사항을 아래 커밋 히스토리에서 꼭 확인해주세요.
[b3040f2](https://github.com/Wraffle-Inc/wraffle/pull/75/commits/b3040f291a8e4608f861f1174c284f36c96be14c)
cc. @gyeong3un2 @Ajeong-Im @eric-hjh @Joy0w0 

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
